### PR TITLE
Consolidated TargetFrameworks. Fixed build and updated packages.

### DIFF
--- a/IpfsCore.sln
+++ b/IpfsCore.sln
@@ -19,8 +19,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Documentation", "doc\Documentation.csproj", "{F3A32EA9-0B2F-46A3-B47A-33B4C04BD423}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/doc/Documentation.csproj
+++ b/doc/Documentation.csproj
@@ -1,7 +1,0 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2</TargetFrameworks>
-  </PropertyGroup>
-
-</Project>

--- a/src/CoreApi/IGenericApi.cs
+++ b/src/CoreApi/IGenericApi.cs
@@ -116,7 +116,6 @@ namespace Ipfs.CoreApi
             CancellationToken cancel = default(CancellationToken)
             );
 
-#if ASYNCSTREAM
         /// <summary>
         ///   Send echo requests to a peer.
         /// </summary>
@@ -158,6 +157,5 @@ namespace Ipfs.CoreApi
             int count = 10,
             CancellationToken cancel = default
             );
-#endif
     }
 }

--- a/src/Cryptography/Keccak.cs
+++ b/src/Cryptography/Keccak.cs
@@ -13,12 +13,7 @@ using System.Text;
 
 namespace Ipfs.Cryptography
 {
-    internal abstract class Keccak :
-#if PORTABLE
-    IHashAlgorithm
-#else
-    System.Security.Cryptography.HashAlgorithm
-#endif
+    internal abstract class Keccak : System.Security.Cryptography.HashAlgorithm
     {
 
         #region Implementation
@@ -31,10 +26,6 @@ namespace Ipfs.Cryptography
         protected ulong[] state;
         protected byte[] buffer;
         protected int buffLength;
-#if PORTABLE || NETSTANDARD14
-        protected byte[] HashValue;
-        protected int HashSizeValue;
-#endif
         protected int keccakR;
 
         public int KeccakR
@@ -65,11 +56,7 @@ namespace Ipfs.Cryptography
             }
         }
 
-        public
-#if (!PORTABLE && !NETSTANDARD14)
-        override
-#endif
-        bool CanReuseTransform
+        public override bool CanReuseTransform
         {
             get
             {
@@ -141,11 +128,7 @@ namespace Ipfs.Cryptography
             count -= amount;
         }
 
-        public
-#if !PORTABLE && !NETSTANDARD14
-        override
-#endif
-        byte[] Hash
+        public override byte[] Hash
         {
             get
             {
@@ -153,11 +136,7 @@ namespace Ipfs.Cryptography
             }
         }
 
-        public
-#if !PORTABLE
-        override
-#endif
-        int HashSize
+        public override int HashSize
         {
             get
             {
@@ -167,22 +146,14 @@ namespace Ipfs.Cryptography
 
         #endregion
 
-        public
-#if !PORTABLE
-        override
-#endif
-        void Initialize()
+        public override void Initialize()
         {
             buffLength = 0;
             state = new ulong[5 * 5];//1600 bits
             HashValue = null;
         }
 
-        protected
-#if !PORTABLE
-        override
-#endif
-        void HashCore(byte[] array, int ibStart, int cbSize)
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {
             if (array == null)
                 throw new ArgumentNullException("array");
@@ -193,10 +164,5 @@ namespace Ipfs.Cryptography
             if (ibStart + cbSize > array.Length)
                 throw new ArgumentOutOfRangeException("ibStart or cbSize");
         }
-
-#if PORTABLE
-        public abstract int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset);
-        public abstract byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount);
-#endif
     }
 }

--- a/src/Cryptography/KeccakManaged.cs
+++ b/src/Cryptography/KeccakManaged.cs
@@ -2,9 +2,6 @@
 // This is a copy of https://bitbucket.org/jdluzen/sha3/raw/d1fd55dc225d18a7fb61515b62d3c8f164d2e788/SHA3Managed/SHA3Managed.cs
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Ipfs.Cryptography
 {
@@ -15,11 +12,7 @@ namespace Ipfs.Cryptography
         {
         }
 
-        protected
-#if !PORTABLE
-        override
-#endif
-        void HashCore(byte[] array, int ibStart, int cbSize)
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {
             base.HashCore(array, ibStart, cbSize);
             if (cbSize == 0)
@@ -50,11 +43,7 @@ namespace Ipfs.Cryptography
             }
         }
 
-        protected
-#if !PORTABLE
-        override
-#endif
-        byte[] HashFinal()
+        protected override byte[] HashFinal()
         {
             int sizeInBytes = SizeInBytes;
             byte[] outb = new byte[HashByteLength];

--- a/src/IpfsCore.csproj
+++ b/src/IpfsCore.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard14;netstandard2;net45;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2;</TargetFrameworks>
     <AssemblyName>Ipfs.Core</AssemblyName>
     <RootNamespace>Ipfs</RootNamespace>
+    <langversion>10.0</langversion>
     <DebugType>portable</DebugType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
@@ -21,12 +22,10 @@
       The InterPlanetary File System is the permanent web. It is a new hypermedia distribution protocol, addressed by content and identities. IPFS enables the creation of completely distributed applications. It aims to make the web faster, safer, and more open.
     </Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>https://github.com/richardschneider/net-ipfs-core/releases</PackageReleaseNotes>
-    <Copyright>© 2015-2019 Richard Schneider</Copyright>
     <PackageTags>ipfs peer-to-peer distributed file-system</PackageTags>
     <IncludeSymbols>True</IncludeSymbols>
-    <PackageProjectUrl>https://github.com/richardschneider/net-ipfs-core</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/richardschneider/net-ipfs-core/master/doc/images/ipfs-cs-logo-64x64.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/ipfs-shipyard/net-ipfs-core</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/ipfs-shipyard/net-ipfs-core/master/doc/images/ipfs-cs-logo-64x64.png</PackageIconUrl>
 
     <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -46,26 +45,18 @@
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />
-    <PackageReference Include="Google.Protobuf" Version="3.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
     <PackageReference Include="SimpleBase" Version="1.3.1" />
-    <PackageReference Include="Grpc.Tools" Version="1.21.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.0.102" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.46.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
     <Protobuf Include="**/*.proto" />
     <EmbeddedResource Include="**/*.proto" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard14'">
-    <DefineConstants>NETSTANDARD14</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0'">
-    <DefineConstants>ASYNCSTREAM</DefineConstants>
-  </PropertyGroup>
 
 </Project>

--- a/test/IpfsCoreTests.csproj
+++ b/test/IpfsCoreTests.csproj
@@ -1,26 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp1.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <langversion>10.0</langversion>
 
     <IsPackable>false</IsPackable>
     <DebugType>portable</DebugType>
     <RootNamespace>Ipfs</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- https://github.com/tonerdo/coverlet -->
-    <!-- Do not collect by default -->
-    <CollectCoverage>false</CollectCoverage>
-    <CoverletOutputFormat>opencover</CoverletOutputFormat>
-    <!--<Exclude>[xunit.*]*</Exclude>-->
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" PrivateAssets="all" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" PrivateAssets="all" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" PrivateAssets="all" />
-    <PackageReference Include="coverlet.msbuild" Version="2.6.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #1. This PR:

- Consolidates all target frameworks to netstandard2.0. 
- Updates outdated packages
- Brings the project back to a buildable state out of the box.

This is a major step towards being able to use the official [multiformats](https://github.com/search?q=org%3Amultiformats+cs-&type=all) cs libraries.