### PR TITLE
Added support for quic v1

### DIFF
--- a/src/IpfsCore.csproj
+++ b/src/IpfsCore.csproj
@@ -9,7 +9,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- https://semver.org/spec/v2.0.0.html -->
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
 
     <!-- Nuget specs -->

--- a/src/NetworkProtocol.cs
+++ b/src/NetworkProtocol.cs
@@ -33,7 +33,7 @@ namespace Ipfs
             NetworkProtocol.Register<UdpNetworkProtocol>();
             NetworkProtocol.Register<P2pNetworkProtocol>();
             NetworkProtocol.RegisterAlias<IpfsNetworkProtocol>();
-            NetworkProtocol.Register<QuicNetworkProtocol>();~
+            NetworkProtocol.Register<QuicNetworkProtocol>();
             NetworkProtocol.Register<QuicV1NetworkProtocol>();
             NetworkProtocol.Register<HttpNetworkProtocol>();
             NetworkProtocol.Register<HttpsNetworkProtocol>();

--- a/src/NetworkProtocol.cs
+++ b/src/NetworkProtocol.cs
@@ -33,7 +33,8 @@ namespace Ipfs
             NetworkProtocol.Register<UdpNetworkProtocol>();
             NetworkProtocol.Register<P2pNetworkProtocol>();
             NetworkProtocol.RegisterAlias<IpfsNetworkProtocol>();
-            NetworkProtocol.Register<QuicNetworkProtocol>();
+            NetworkProtocol.Register<QuicNetworkProtocol>();~
+            NetworkProtocol.Register<QuicV1NetworkProtocol>();
             NetworkProtocol.Register<HttpNetworkProtocol>();
             NetworkProtocol.Register<HttpsNetworkProtocol>();
             NetworkProtocol.Register<DccpNetworkProtocol>();
@@ -395,6 +396,12 @@ namespace Ipfs
     {
         public override string Name { get { return "quic"; } }
         public override uint Code { get { return 460; } }
+    }
+
+    class QuicV1NetworkProtocol : ValuelessNetworkProtocol
+    {
+        public override string Name { get { return "quic-v1"; } }
+        public override uint Code { get { return 461; } }
     }
 
     class HttpNetworkProtocol : ValuelessNetworkProtocol


### PR DESCRIPTION
This PR adds support for quic v1, which recent landed as the default in Kubo 0.18.
This change mirrors the one in [`js-multihash`](https://github.com/multiformats/js-multiaddr/pull/294).

closes #15