### PR TITLE
Enable nullable globally and fix issues

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <langversion>10.0</langversion>
+  </PropertyGroup>
+
+</Project>

--- a/src/CoreApi/AddFileOptions.cs
+++ b/src/CoreApi/AddFileOptions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Ipfs.CoreApi
 {
@@ -92,11 +90,11 @@ namespace Ipfs.CoreApi
         ///   <b>ProtectionKey</b> and <see cref="RawLeaves"/> are mutually exclusive.
         /// </remarks>
         /// <seealso cref="IKeyApi"/>
-        public string ProtectionKey { get; set; }
+        public string? ProtectionKey { get; set; }
 
         /// <summary>
         ///   Used to report the progress of a file transfer.
         /// </summary>
-        public IProgress<TransferProgress> Progress { get; set; }
+        public IProgress<TransferProgress>? Progress { get; set; }
     }
 }

--- a/src/CoreApi/BitswapData.cs
+++ b/src/CoreApi/BitswapData.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Ipfs.CoreApi
 {
@@ -17,12 +15,12 @@ namespace Ipfs.CoreApi
         /// <summary>
         ///   The content that is wanted.
         /// </summary>
-        public IEnumerable<Cid> Wantlist;
+        public IEnumerable<Cid>? Wantlist;
 
         /// <summary>
         ///   The known peers.
         /// </summary>
-        public IEnumerable<MultiHash> Peers;
+        public IEnumerable<MultiHash>? Peers;
 
         /// <summary>
         ///   The number of blocks sent by other peers.

--- a/src/CoreApi/BitswapLedger.cs
+++ b/src/CoreApi/BitswapLedger.cs
@@ -16,7 +16,7 @@ namespace Ipfs.CoreApi
         /// <value>
         ///   The peer that is being monitored.
         /// </value>
-        public Peer Peer { get; set; }
+        public Peer? Peer { get; set; }
 
         /// <summary>
         ///   The number of blocks exchanged with the <see cref="Peer"/>.

--- a/src/CoreApi/FileStat.cs
+++ b/src/CoreApi/FileStat.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Ipfs.CoreApi
 {
@@ -13,7 +11,7 @@ namespace Ipfs.CoreApi
         /// <summary>
         /// The <see cref="Cid"/> of the file or directory.
         /// </summary>
-        public Cid Hash { get; set; }
+        public Cid? Hash { get; set; }
 
         /// <summary>
         ///   The serialised size (in bytes) of the linked node.

--- a/src/CoreApi/IBitswapApi.cs
+++ b/src/CoreApi/IBitswapApi.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -44,7 +42,7 @@ namespace Ipfs.CoreApi
         /// <remarks>
         ///   Waits for another peer to supply the block with the <paramref name="id"/>.
         /// </remarks>
-        Task<IDataBlock> GetAsync(Cid id, CancellationToken cancel = default(CancellationToken));
+        Task<IDataBlock> GetAsync(Cid id, CancellationToken cancel = default);
 
         /// <summary>
         ///   The blocks that are needed by a peer.
@@ -60,7 +58,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value
         ///   contains the sequence of blocks needed by the <paramref name="peer"/>.
         /// </returns>
-        Task<IEnumerable<Cid>> WantsAsync(MultiHash peer = null, CancellationToken cancel = default(CancellationToken));
+        Task<IEnumerable<Cid>> WantsAsync(MultiHash? peer = null, CancellationToken cancel = default);
 
         /// <summary>
         ///   Remove the CID from the want list.
@@ -78,7 +76,7 @@ namespace Ipfs.CoreApi
         ///   Any outstanding <see cref="GetAsync(Cid, CancellationToken)"/> for the
         ///   <paramref name="id"/> are cancelled.
         /// </remarks>
-        Task UnwantAsync(Cid id, CancellationToken cancel = default(CancellationToken));
+        Task UnwantAsync(Cid id, CancellationToken cancel = default);
 
         /// <summary>
         ///   Gets information on the blocks exchanged with a specific <see cref="Peer"/>.
@@ -94,6 +92,6 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value
         ///   contains the <see cref="BitswapLedger"/> for the <paramref name="peer"/>.
         /// </returns>
-        Task<BitswapLedger> LedgerAsync(Peer peer, CancellationToken cancel = default(CancellationToken));
+        Task<BitswapLedger> LedgerAsync(Peer peer, CancellationToken cancel = default);
     }
 }

--- a/src/CoreApi/IContentRouting.cs
+++ b/src/CoreApi/IContentRouting.cs
@@ -1,8 +1,5 @@
-﻿using Ipfs;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -32,7 +29,7 @@ namespace Ipfs.CoreApi
         /// <returns>
         ///   A task that represents the asynchronous operation.
         /// </returns>
-        Task ProvideAsync(Cid cid, bool advertise = true, CancellationToken cancel = default(CancellationToken));
+        Task ProvideAsync(Cid cid, bool advertise = true, CancellationToken cancel = default);
 
         /// <summary>
         ///   Find the providers for the specified content.
@@ -56,7 +53,7 @@ namespace Ipfs.CoreApi
         Task<IEnumerable<Peer>> FindProvidersAsync(
             Cid id,
             int limit = 20,
-            Action<Peer> providerFound = null,
-            CancellationToken cancel = default(CancellationToken));
+            Action<Peer>? providerFound = null,
+            CancellationToken cancel = default);
     }
 }

--- a/src/CoreApi/IFileSystemApi.cs
+++ b/src/CoreApi/IFileSystemApi.cs
@@ -29,7 +29,7 @@ namespace Ipfs.CoreApi
         ///    A task that represents the asynchronous operation. The task's value is
         ///    the file's node.
         /// </returns>
-        Task<IFileSystemNode> AddFileAsync(string path, AddFileOptions options = default(AddFileOptions), CancellationToken cancel = default(CancellationToken));
+        Task<IFileSystemNode> AddFileAsync(string path, AddFileOptions? options = default, CancellationToken cancel = default);
 
         /// <summary>
         ///   Add some text to the interplanetary file system.
@@ -47,7 +47,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value is
         ///   the text's node.
         /// </returns>
-        Task<IFileSystemNode> AddTextAsync(string text, AddFileOptions options = default(AddFileOptions), CancellationToken cancel = default(CancellationToken));
+        Task<IFileSystemNode> AddTextAsync(string text, AddFileOptions? options = default, CancellationToken cancel = default);
 
         /// <summary>
         ///   Add a <see cref="Stream"/> to interplanetary file system.
@@ -68,7 +68,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value is
         ///   the data's node.
         /// </returns>
-        Task<IFileSystemNode> AddAsync(Stream stream, string name = "", AddFileOptions options = default(AddFileOptions), CancellationToken cancel = default(CancellationToken));
+        Task<IFileSystemNode> AddAsync(Stream stream, string name = "", AddFileOptions? options = default, CancellationToken cancel = default);
 
         /// <summary>
         ///   Add a directory and its files to the interplanetary file system.
@@ -89,7 +89,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value is
         ///   the directory's node.
         /// </returns>
-        Task<IFileSystemNode> AddDirectoryAsync(string path, bool recursive = true, AddFileOptions options = default(AddFileOptions), CancellationToken cancel = default(CancellationToken));
+        Task<IFileSystemNode> AddDirectoryAsync(string path, bool recursive = true, AddFileOptions? options = default, CancellationToken cancel = default);
 
         /// <summary>
         ///   Reads the content of an existing IPFS file as text.
@@ -105,7 +105,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value is
         ///   the contents of the <paramref name="path"/> as a <see cref="string"/>.
         /// </returns>
-        Task<String> ReadAllTextAsync(string path, CancellationToken cancel = default(CancellationToken));
+        Task<String> ReadAllTextAsync(string path, CancellationToken cancel = default);
 
         /// <summary>
         ///   Reads an existing IPFS file.
@@ -124,7 +124,7 @@ namespace Ipfs.CoreApi
         /// <remarks>
         ///   The returned <see cref="Stream"/> must be disposed.
         /// </remarks>
-        Task<Stream> ReadFileAsync(string path, CancellationToken cancel = default(CancellationToken));
+        Task<Stream> ReadFileAsync(string path, CancellationToken cancel = default);
 
         /// <summary>
         ///   Reads an existing IPFS file with the specified offset and length.
@@ -150,7 +150,7 @@ namespace Ipfs.CoreApi
         /// <remarks>
         ///   The returned <see cref="Stream"/> must be disposed.
         /// </remarks>
-        Task<Stream> ReadFileAsync(string path, long offset, long count = 0, CancellationToken cancel = default(CancellationToken));
+        Task<Stream> ReadFileAsync(string path, long offset, long count = 0, CancellationToken cancel = default);
 
         /// <summary>
         ///   Get information about the file or directory.
@@ -167,7 +167,7 @@ namespace Ipfs.CoreApi
         ///   an <see cref="IFileSystemNode"/>  The <see cref="IDataBlock.DataBytes"/>
         ///   and <see cref="IDataBlock.DataStream"/> are set to <b>null</b>.
         /// </returns>
-        Task<IFileSystemNode> ListFileAsync(string path, CancellationToken cancel = default(CancellationToken));
+        Task<IFileSystemNode> ListFileAsync(string path, CancellationToken cancel = default);
 
         /// <summary>
         ///   Download IPFS objects as a TAR archive.
@@ -193,6 +193,6 @@ namespace Ipfs.CoreApi
         ///   sub-directories are returned; e.g. it is recursive.
         ///   </para>
         /// </remarks>
-        Task<Stream> GetAsync(string path, bool compress = false, CancellationToken cancel = default(CancellationToken));
+        Task<Stream> GetAsync(string path, bool compress = false, CancellationToken cancel = default);
     }
 }

--- a/src/CoreApi/IGenericApi.cs
+++ b/src/CoreApi/IGenericApi.cs
@@ -27,7 +27,7 @@ namespace Ipfs.CoreApi
         ///    A task that represents the asynchronous operation. The task's value is
         ///    the <see cref="Peer"/> information.
         /// </returns>
-        Task<Peer> IdAsync(MultiHash peer = null, CancellationToken cancel = default(CancellationToken));
+        Task<Peer> IdAsync(MultiHash? peer = null, CancellationToken cancel = default);
 
         /// <summary>
         ///   Get the version information.
@@ -36,7 +36,7 @@ namespace Ipfs.CoreApi
         ///    A task that represents the asynchronous operation. The task's value is
         ///    a <see cref="Dictionary{TKey, TValue}"/> of values.
         /// </returns>
-        Task<Dictionary<string, string>> VersionAsync(CancellationToken cancel = default(CancellationToken));
+        Task<Dictionary<string, string>> VersionAsync(CancellationToken cancel = default);
 
         /// <summary>
         ///   Stop the IPFS peer.
@@ -69,7 +69,7 @@ namespace Ipfs.CoreApi
         Task<string> ResolveAsync(
             string name,
             bool recursive = true,
-            CancellationToken cancel = default(CancellationToken)
+            CancellationToken cancel = default
             );
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Ipfs.CoreApi
         Task<IEnumerable<PingResult>> PingAsync(
             MultiHash peer,
             int count = 10,
-            CancellationToken cancel = default(CancellationToken)
+            CancellationToken cancel = default
             );
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Ipfs.CoreApi
         Task<IEnumerable<PingResult>> PingAsync(
             MultiAddress address,
             int count = 10,
-            CancellationToken cancel = default(CancellationToken)
+            CancellationToken cancel = default
             );
 
         /// <summary>

--- a/src/CoreApi/IKeyApi.cs
+++ b/src/CoreApi/IKeyApi.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -40,7 +38,7 @@ namespace Ipfs.CoreApi
             string name,
             string keyType,
             int size,
-            CancellationToken cancel = default(CancellationToken));
+            CancellationToken cancel = default);
 
         /// <summary>
         ///   List all the keys.
@@ -52,7 +50,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's result is
         ///   a sequence of IPFS keys.
         /// </returns>
-        Task<IEnumerable<IKey>> ListAsync(CancellationToken cancel = default(CancellationToken));
+        Task<IEnumerable<IKey>> ListAsync(CancellationToken cancel = default);
 
         /// <summary>
         ///   Delete the specified key.
@@ -67,7 +65,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's result is
         ///   the key that was deleted.
         /// </returns>
-        Task<IKey> RemoveAsync(string name, CancellationToken cancel = default(CancellationToken));
+        Task<IKey> RemoveAsync(string name, CancellationToken cancel = default);
 
         /// <summary>
         ///   Rename the specified key.
@@ -85,7 +83,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's result is
         ///   a sequence of IPFS keys that were renamed.
         /// </returns>
-        Task<IKey> RenameAsync(string oldName, string newName, CancellationToken cancel = default(CancellationToken));
+        Task<IKey> RenameAsync(string oldName, string newName, CancellationToken cancel = default);
 
         /// <summary>
         ///   Export a key to a PEM encoded password protected PKCS #8 container.
@@ -103,7 +101,7 @@ namespace Ipfs.CoreApi
         ///    A task that represents the asynchronous operation. The task's result is
         ///    the password protected PEM string.
         /// </returns>
-        Task<string> ExportAsync(string name, char[] password, CancellationToken cancel = default(CancellationToken));
+        Task<string> ExportAsync(string name, char[] password, CancellationToken cancel = default);
 
         /// <summary>
         ///   Import a key from a PEM encoded password protected PKCS #8 container.
@@ -124,6 +122,6 @@ namespace Ipfs.CoreApi
         ///    A task that represents the asynchronous operation. The task's result
         ///    is the newly imported key.
         /// </returns>
-        Task<IKey> ImportAsync(string name, string pem, char[] password = null, CancellationToken cancel = default(CancellationToken));
+        Task<IKey> ImportAsync(string name, string pem, char[]? password = null, CancellationToken cancel = default);
     }
 }

--- a/src/CoreApi/IMfsApi.cs
+++ b/src/CoreApi/IMfsApi.cs
@@ -29,7 +29,7 @@ namespace Ipfs.CoreApi
         /// <param name="cancel">
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
-        Task CopyAsync(string sourceMfsPathOrCid, string destMfsPath, bool? parents = null, CancellationToken cancel = default(CancellationToken));
+        Task CopyAsync(string sourceMfsPathOrCid, string destMfsPath, bool? parents = null, CancellationToken cancel = default);
 
         /// <summary>
         ///   Flush a given path's data to disk.
@@ -43,7 +43,7 @@ namespace Ipfs.CoreApi
         /// <returns>
         ///   <see cref="Cid"/> of the flushed path.
         /// </returns>
-        Task<Cid> FlushAsync(string path = null, CancellationToken cancel = default(CancellationToken));
+        Task<Cid> FlushAsync(string? path = null, CancellationToken cancel = default);
 
         /// <summary>
         ///   List directories in the local mutable namespace.
@@ -59,7 +59,7 @@ namespace Ipfs.CoreApi
         /// <remarks>
         ///   Paramter long is ommitted and should always be passed as true in implementation.
         /// </remarks>
-        Task<IEnumerable<IFileSystemNode>> ListAsync(string path, bool? U = null, CancellationToken cancel = default(CancellationToken));
+        Task<IEnumerable<IFileSystemNode>> ListAsync(string path, bool? U = null, CancellationToken cancel = default);
 
         /// <summary>
         ///   Make directories in the local mutable namespace.
@@ -80,7 +80,7 @@ namespace Ipfs.CoreApi
         /// <param name="cancel">
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
-        Task MakeDirectoryAsync(string path, bool? parents = null, int? cidVersion = null, string multiHash = null, CancellationToken cancel = default(CancellationToken));
+        Task MakeDirectoryAsync(string path, bool? parents = null, int? cidVersion = null, string? multiHash = null, CancellationToken cancel = default);
 
         /// <summary>
         ///    Move file or directory to another path in MFS.
@@ -94,7 +94,7 @@ namespace Ipfs.CoreApi
         /// <param name="cancel">
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
-        Task MoveAsync(string sourceMfsPath, string destMfsPath, CancellationToken cancel = default(CancellationToken));
+        Task MoveAsync(string sourceMfsPath, string destMfsPath, CancellationToken cancel = default);
 
         /// <summary>
         ///   Read a file from MFS.
@@ -111,7 +111,7 @@ namespace Ipfs.CoreApi
         /// <param name="cancel">
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
-        Task<string> ReadFileAsync(string path, Int64? offset = null, Int64? count = null, CancellationToken cancel = default(CancellationToken));
+        Task<string> ReadFileAsync(string path, Int64? offset = null, Int64? count = null, CancellationToken cancel = default);
 
         /// <summary>
         ///   Remove a file or directory or from MFS.
@@ -128,7 +128,7 @@ namespace Ipfs.CoreApi
         /// <param name="cancel">
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
-        Task RemoveAsync(string path, bool? recursive = null, bool? force = null, CancellationToken cancel = default(CancellationToken));
+        Task RemoveAsync(string path, bool? recursive = null, bool? force = null, CancellationToken cancel = default);
 
         /// <summary>
         ///   Get file or directory status info.
@@ -142,7 +142,7 @@ namespace Ipfs.CoreApi
         /// <returns>
         ///   <see cref="FileStatResult"/> information about the path.
         /// </returns>
-        Task<FileStatResult> StatAsync(string path, CancellationToken cancel = default(CancellationToken));
+        Task<FileStatResult> StatAsync(string path, CancellationToken cancel = default);
 
         /// <summary>
         ///   Get file or directory status info including information about locality of data.
@@ -160,7 +160,7 @@ namespace Ipfs.CoreApi
         ///   <see cref="FileStatWithLocalityResult"/> information about the path including 
         ///   additional information on locality if withLocal=true.
         /// </returns>
-        Task<FileStatWithLocalityResult> StatAsync(string path, bool withLocal, CancellationToken cancel = default(CancellationToken));
+        Task<FileStatWithLocalityResult> StatAsync(string path, bool withLocal, CancellationToken cancel = default);
 
         /// <summary>
         ///   Append to (modify) a text file in MFS.
@@ -214,6 +214,6 @@ namespace Ipfs.CoreApi
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
         /// <seealso cref="MfsWriteOptions"/>
-        Task WriteAsync(string path, Stream data, MfsWriteOptions options, CancellationToken cancel = default(CancellationToken));
+        Task WriteAsync(string path, Stream data, MfsWriteOptions options, CancellationToken cancel = default);
     }
 }

--- a/src/CoreApi/IObjectApi.cs
+++ b/src/CoreApi/IObjectApi.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -33,7 +31,7 @@ namespace Ipfs.CoreApi
         /// <remarks>
         ///   Equivalent to <c>NewAsync("unixfs-dir")</c>.
         /// </remarks>
-        Task<DagNode> NewDirectoryAsync(CancellationToken cancel = default(CancellationToken));
+        Task<DagNode> NewDirectoryAsync(CancellationToken cancel = default);
 
         /// <summary>
         ///   Create a new MerkleDAG node, using a specific layout.
@@ -49,7 +47,7 @@ namespace Ipfs.CoreApi
         /// <remarks>
         ///  Caveat: So far, only UnixFS object layouts are supported.
         /// </remarks>
-        Task<DagNode> NewAsync(string template = null, CancellationToken cancel = default(CancellationToken));
+        Task<DagNode> NewAsync(string? template = null, CancellationToken cancel = default);
 
         /// <summary>
         ///   Fetch a MerkleDAG node.
@@ -64,7 +62,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value
         ///   is a <see cref="DagNode"/>.
         /// </returns>
-        Task<DagNode> GetAsync(Cid id, CancellationToken cancel = default(CancellationToken));
+        Task<DagNode> GetAsync(Cid id, CancellationToken cancel = default);
 
         /// <summary>
         ///   Information on a MerkleDag node.
@@ -79,7 +77,7 @@ namespace Ipfs.CoreApi
         ///    A task that represents the asynchronous operation. The task's value
         ///    contains the <see cref="ObjectStat"/>.
         /// </returns>
-        Task<ObjectStat> StatAsync(Cid id, CancellationToken cancel = default(CancellationToken));
+        Task<ObjectStat> StatAsync(Cid id, CancellationToken cancel = default);
 
         /// <summary>
         ///   Store a MerkleDAG node.
@@ -97,7 +95,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value
         ///   is a <see cref="DagNode"/>.
         /// </returns>
-        Task<DagNode> PutAsync(byte[] data, IEnumerable<IMerkleLink> links = null, CancellationToken cancel = default(CancellationToken));
+        Task<DagNode> PutAsync(byte[] data, IEnumerable<IMerkleLink>? links = null, CancellationToken cancel = default);
 
         /// <summary>
         ///   Store a MerkleDAG node.
@@ -110,7 +108,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value
         ///   is a <see cref="DagNode"/>.
         /// </returns>
-        Task<DagNode> PutAsync(DagNode node, CancellationToken cancel = default(CancellationToken));
+        Task<DagNode> PutAsync(DagNode node, CancellationToken cancel = default);
 
         /// <summary>
         ///   Get the data of a MerkleDAG node.
@@ -128,7 +126,7 @@ namespace Ipfs.CoreApi
         /// <remarks>
         ///   The caller must dispose the returned <see cref="Stream"/>.
         /// </remarks>
-        Task<Stream> DataAsync(Cid id, CancellationToken cancel = default(CancellationToken));
+        Task<Stream> DataAsync(Cid id, CancellationToken cancel = default);
 
         /// <summary>
         ///   Get the links of a MerkleDAG node.
@@ -151,7 +149,7 @@ namespace Ipfs.CoreApi
         ///   {
         ///     var i = 0;
         ///     var allLinks = new List&lt;IMerkleLink>();
-        ///     while (cid != null)
+        ///     while (cid is not null)
         ///     {
         ///        var links = await ipfs.Object.LinksAsync(cid);
         ///        allLinks.AddRange(links);
@@ -161,7 +159,6 @@ namespace Ipfs.CoreApi
         ///   }
         ///   </code>
         /// </remarks>
-        Task<IEnumerable<IMerkleLink>> LinksAsync(Cid id, CancellationToken cancel = default(CancellationToken));
-
+        Task<IEnumerable<IMerkleLink>> LinksAsync(Cid id, CancellationToken cancel = default);
     }
 }

--- a/src/CoreApi/IPubSubApi.cs
+++ b/src/CoreApi/IPubSubApi.cs
@@ -33,7 +33,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value is
         ///   a sequence of <see cref="string"/> for each topic.
         /// </returns>
-        Task<IEnumerable<string>> SubscribedTopicsAsync(CancellationToken cancel = default(CancellationToken));
+        Task<IEnumerable<string>> SubscribedTopicsAsync(CancellationToken cancel = default);
 
         /// <summary>
         ///   Get the peers that are pubsubing with us.
@@ -48,7 +48,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value is
         ///   a sequence of <see cref="Peer"/>.
         /// </returns>
-        Task<IEnumerable<Peer>> PeersAsync(string topic = null, CancellationToken cancel = default(CancellationToken));
+        Task<IEnumerable<Peer>> PeersAsync(string? topic = null, CancellationToken cancel = default);
 
         /// <summary>
         ///   Publish a string message to a given topic.
@@ -65,7 +65,7 @@ namespace Ipfs.CoreApi
         /// <returns>
         ///   A task that represents the asynchronous operation.
         /// </returns>
-        Task PublishAsync(string topic, string message, CancellationToken cancel = default(CancellationToken));
+        Task PublishAsync(string topic, string message, CancellationToken cancel = default);
 
         /// <summary>
         ///   Publish a binary message to a given topic.
@@ -82,7 +82,7 @@ namespace Ipfs.CoreApi
         /// <returns>
         ///   A task that represents the asynchronous operation.
         /// </returns>
-        Task PublishAsync(string topic, byte[] message, CancellationToken cancel = default(CancellationToken));
+        Task PublishAsync(string topic, byte[] message, CancellationToken cancel = default);
 
         /// <summary>
         ///   Publish a binary message to a given topic.
@@ -99,7 +99,7 @@ namespace Ipfs.CoreApi
         /// <returns>
         ///   A task that represents the asynchronous operation.
         /// </returns>
-        Task PublishAsync(string topic, Stream message, CancellationToken cancel = default(CancellationToken));
+        Task PublishAsync(string topic, Stream message, CancellationToken cancel = default);
 
         /// <summary>
         ///   Subscribe to messages on a given topic.

--- a/src/CoreApi/IStatsApi.cs
+++ b/src/CoreApi/IStatsApi.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ipfs.CoreApi
@@ -22,7 +19,7 @@ namespace Ipfs.CoreApi
         ///   the current <see cref="BandwidthData"/>.
         /// </returns>
         /// <seealso cref="ISwarmApi"/>
-        Task<BandwidthData> BandwidthAsync(CancellationToken cancel = default(CancellationToken));
+        Task<BandwidthData> BandwidthAsync(CancellationToken cancel = default);
 
         /// <summary>
         ///   Get statistics on the blocks exchanged with other peers.
@@ -35,7 +32,7 @@ namespace Ipfs.CoreApi
         ///   the current <see cref="BitswapData"/>.
         /// </returns>
         /// <seealso cref="IBitswapApi"/>
-        Task<BitswapData> BitswapAsync(CancellationToken cancel = default(CancellationToken));
+        Task<BitswapData> BitswapAsync(CancellationToken cancel = default);
 
         /// <summary>
         ///   Get statistics on the repository.
@@ -51,6 +48,6 @@ namespace Ipfs.CoreApi
         ///   Same as <see cref="IBlockRepositoryApi.StatisticsAsync(CancellationToken)"/>.
         /// </remarks>
         /// <seealso cref="IBlockRepositoryApi"/>
-        Task<RepositoryData> RepositoryAsync(CancellationToken cancel = default(CancellationToken));
+        Task<RepositoryData> RepositoryAsync(CancellationToken cancel = default);
     }
 }

--- a/src/CoreApi/MfsWriteOptions.cs
+++ b/src/CoreApi/MfsWriteOptions.cs
@@ -78,6 +78,6 @@ namespace Ipfs.CoreApi
         ///   The default is <b>null</b> and the server will use its default algorithm name.
         /// </value>
         /// <seealso cref="MultiHash.DefaultAlgorithmName"/>
-        public string Hash { get; set; } = null;
+        public string? Hash { get; set; } = null;
     }
 }

--- a/src/CoreApi/PingResult.cs
+++ b/src/CoreApi/PingResult.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Ipfs.CoreApi
 {
@@ -22,6 +20,6 @@ namespace Ipfs.CoreApi
         /// <summary>
         ///   The text to echo.
         /// </summary>
-        public string Text { get; set; }
+        public string? Text { get; set; }
     }
 }

--- a/src/CoreApi/RepositoryData.cs
+++ b/src/CoreApi/RepositoryData.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Ipfs.CoreApi
+﻿namespace Ipfs.CoreApi
 {
     /// <summary>
     ///   The statistics for <see cref="IStatsApi.RepositoryAsync"/>.
@@ -15,7 +11,7 @@ namespace Ipfs.CoreApi
         /// <value>
         ///   The number of blocks in the <see cref="IBlockRepositoryApi">repository</see>.
         /// </value>
-        public ulong NumObjects;
+        public ulong NumObjects { get; set; }
 
         /// <summary>
         ///   The total number bytes in the repository.
@@ -23,7 +19,7 @@ namespace Ipfs.CoreApi
         /// <value>
         ///   The total number bytes in the <see cref="IBlockRepositoryApi">repository</see>.
         /// </value>
-        public ulong RepoSize;
+        public ulong RepoSize { get; set; }
 
         /// <summary>
         ///   The fully qualified path to the repository.
@@ -31,7 +27,7 @@ namespace Ipfs.CoreApi
         /// <value>
         ///   The directory of the <see cref="IBlockRepositoryApi">repository</see>.
         /// </value>
-        public string RepoPath;
+        public string RepoPath { get; set; } = string.Empty;
 
         /// <summary>
         ///   The version number of the repository.
@@ -39,7 +35,7 @@ namespace Ipfs.CoreApi
         /// <value>
         ///  The version number of the <see cref="IBlockRepositoryApi">repository</see>.
         /// </value>
-        public string Version;
+        public string Version { get; set; } = string.Empty;
 
         /// <summary>
         ///   The maximum number of bytes allowed in the repository.
@@ -47,7 +43,6 @@ namespace Ipfs.CoreApi
         /// <value>
         ///  Max bytes allowed in the <see cref="IBlockRepositoryApi">repository</see>.
         /// </value>
-        public ulong StorageMax;
-
+        public ulong StorageMax { get; set; }
     }
 }

--- a/src/CoreApi/TransferProgress.cs
+++ b/src/CoreApi/TransferProgress.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Ipfs.CoreApi
 {
@@ -11,15 +9,15 @@ namespace Ipfs.CoreApi
     public class TransferProgress
     {
         /// <summary>
-        ///   The name of the item being trasfered.
+        ///   The name of the item being transferred.
         /// </summary>
         /// <value>
         ///   Typically, a relative file path.
         /// </value>
-        public string Name;
+        public string? Name;
 
         /// <summary>
-        ///   The cumuative number of bytes transfered for
+        ///   The cumuative number of bytes transferred for
         ///   the <see cref="Name"/>.
         /// </summary>
         public ulong Bytes;

--- a/src/Cryptography/DoubleSha256.cs
+++ b/src/Cryptography/DoubleSha256.cs
@@ -5,10 +5,10 @@ using System.Text;
 
 namespace Ipfs.Cryptography
 {
-    class DoubleSha256 : HashAlgorithm
+    internal class DoubleSha256 : HashAlgorithm
     {
-        HashAlgorithm digest = SHA256.Create();
-        byte[] round1;
+        private readonly HashAlgorithm digest = SHA256.Create();
+        private byte[]? round1;
 
         public override void Initialize()
         {
@@ -20,7 +20,7 @@ namespace Ipfs.Cryptography
 
         protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {
-            if (round1 != null)
+            if (round1 is not null)
                 throw new NotSupportedException("Already called.");
 
             round1 = digest.ComputeHash(array, ibStart, cbSize);
@@ -31,6 +31,5 @@ namespace Ipfs.Cryptography
             digest.Initialize();
             return digest.ComputeHash(round1);
         }
-
     }
 }

--- a/src/Cryptography/IdentityHash.cs
+++ b/src/Cryptography/IdentityHash.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Security.Cryptography;
-using System.Text;
 
 namespace Ipfs.Cryptography
 {
-    class IdentityHash : HashAlgorithm
+    internal class IdentityHash : HashAlgorithm
     {
-        byte[] digest;
+        byte[]? digest;
 
         public override void Initialize()
         {
@@ -15,7 +13,7 @@ namespace Ipfs.Cryptography
 
         protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {
-            if (digest == null)
+            if (digest is null)
             {
                 digest = new byte[cbSize];
                 Buffer.BlockCopy(array, ibStart, digest, 0, cbSize);
@@ -30,7 +28,7 @@ namespace Ipfs.Cryptography
 
         protected override byte[] HashFinal()
         {
-            return digest;
+            return digest ?? Array.Empty<byte>();
         }
     }
 }

--- a/src/Cryptography/Keccak.cs
+++ b/src/Cryptography/Keccak.cs
@@ -5,11 +5,9 @@
  * 
  * The SHA3 package doesn't create .Net Standard package.
  * This is a copy of https://bitbucket.org/jdluzen/sha3/raw/d1fd55dc225d18a7fb61515b62d3c8f164d2e788/SHA3/SHA3.cs
+ * with nullable modifications.
  */
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Ipfs.Cryptography
 {
@@ -23,8 +21,8 @@ namespace Ipfs.Cryptography
 
         public readonly ulong[] RoundConstants;
 
-        protected ulong[] state;
-        protected byte[] buffer;
+        protected ulong[] state = new ulong[5 * 5];  //1600 bits
+        protected byte[]? buffer;
         protected int buffLength;
         protected int keccakR;
 
@@ -121,7 +119,7 @@ namespace Ipfs.Cryptography
 
         protected void AddToBuffer(byte[] array, ref int offset, ref int count)
         {
-            int amount = Math.Min(count, buffer.Length - buffLength);
+            int amount = Math.Min(count, buffer!.Length - buffLength);
             Buffer.BlockCopy(array, offset, buffer, buffLength, amount);
             offset += amount;
             buffLength += amount;
@@ -149,14 +147,11 @@ namespace Ipfs.Cryptography
         public override void Initialize()
         {
             buffLength = 0;
-            state = new ulong[5 * 5];//1600 bits
             HashValue = null;
         }
 
         protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {
-            if (array == null)
-                throw new ArgumentNullException("array");
             if (ibStart < 0)
                 throw new ArgumentOutOfRangeException("ibStart");
             if (cbSize > array.Length)

--- a/src/Cryptography/KeccakManaged.cs
+++ b/src/Cryptography/KeccakManaged.cs
@@ -18,8 +18,7 @@ namespace Ipfs.Cryptography
             if (cbSize == 0)
                 return;
             int sizeInBytes = SizeInBytes;
-            if (buffer == null)
-                buffer = new byte[sizeInBytes];
+            buffer ??= new byte[sizeInBytes];
             int stride = sizeInBytes >> 3;
             ulong[] utemps = new ulong[stride];
             if (buffLength == sizeInBytes)
@@ -48,7 +47,7 @@ namespace Ipfs.Cryptography
             int sizeInBytes = SizeInBytes;
             byte[] outb = new byte[HashByteLength];
             //    padding
-            if (buffer == null)
+            if (buffer is null)
                 buffer = new byte[sizeInBytes];
             else
                 Array.Clear(buffer, buffLength, sizeInBytes - buffLength);

--- a/src/DagLink.cs
+++ b/src/DagLink.cs
@@ -1,14 +1,9 @@
 ﻿using Google.Protobuf;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Ipfs
 {
-
     /// <summary>
     ///   A link to another node in the IPFS Merkle DAG.
     /// </summary>
@@ -20,7 +15,7 @@ namespace Ipfs
         /// <param name="name">The name associated with the linked node.</param>
         /// <param name="id">The <see cref="Cid"/> of the linked node.</param>
         /// <param name="size">The serialised size (in bytes) of the linked node.</param>
-        public DagLink(string name, Cid id, long size)
+        public DagLink(string? name, Cid id, long size)
         {
             this.Name = name;
             this.Id = id;
@@ -51,7 +46,7 @@ namespace Ipfs
         /// </param>
         public DagLink(Stream stream)
         {
-            Read(stream);
+            (Name, Id, Size) = Read(stream);
         }
 
         /// <summary>
@@ -64,11 +59,11 @@ namespace Ipfs
         /// </param>
         public DagLink(CodedInputStream stream)
         {
-            Read(stream);
+            (Name, Id, Size) = Read(stream);
         }
 
         /// <inheritdoc />
-        public string Name { get; private set; }
+        public string? Name { get; private set; }
 
         /// <inheritdoc />
         public Cid Id { get; private set; }
@@ -98,13 +93,10 @@ namespace Ipfs
         /// </param>
         public void Write(CodedOutputStream stream)
         {
-            if (stream == null)
-                throw new ArgumentNullException("stream");
-
             stream.WriteTag(1, WireFormat.WireType.LengthDelimited);
             Id.Write(stream);
 
-            if (Name != null)
+            if (Name is not null)
             {
                 stream.WriteTag(2, WireFormat.WireType.LengthDelimited);
                 stream.WriteString(Name);
@@ -114,34 +106,44 @@ namespace Ipfs
             stream.WriteInt64(Size);
         }
 
-        void Read(Stream stream)
+        private (string?, Cid, long) Read(Stream stream)
         {
             using (var cis = new CodedInputStream(stream, true))
             {
-                Read(cis);
+                return Read(cis);
             }
         }
 
-        void Read(CodedInputStream stream)
+        private (string?, Cid, long) Read(CodedInputStream stream)
         {
+            string? name = null;
+            Cid? id = null;
+            long size = 0;
             while (!stream.IsAtEnd)
             {
                 var tag = stream.ReadTag();
                 switch (WireFormat.GetTagFieldNumber(tag))
                 {
                     case 1:
-                        Id = Cid.Read(stream);
+                        id = Cid.Read(stream);
                         break;
                     case 2:
-                        Name = stream.ReadString();
+                        name = stream.ReadString();
                         break;
                     case 3:
-                        Size = stream.ReadInt64();
+                        size = stream.ReadInt64();
                         break;
                     default:
                         throw new InvalidDataException("Unknown field number");
                 }
             }
+
+            if (id is null)
+            {
+                throw new InvalidDataException($"Missing CID id from record");
+            }
+
+            return (name, id, size);
         }
 
         /// <summary>

--- a/src/DagNode.cs
+++ b/src/DagNode.cs
@@ -19,9 +19,9 @@ namespace Ipfs
     [DataContract]
     public class DagNode : IMerkleNode<IMerkleLink>
     {
-        Cid id;
-        string hashAlgorithm = MultiHash.DefaultAlgorithmName;
-        long? size;
+        private Cid? id;
+        private string hashAlgorithm = MultiHash.DefaultAlgorithmName;
+        private long? size;
 
         /// <summary>
         ///   Create a new instance of a <see cref="DagNode"/> with the specified
@@ -37,10 +37,10 @@ namespace Ipfs
         ///   The name of the hashing algorithm to use; defaults to 
         ///   <see cref="MultiHash.DefaultAlgorithmName"/>.
         /// </param>
-        public DagNode(byte[] data, IEnumerable<IMerkleLink> links = null, string hashAlgorithm = MultiHash.DefaultAlgorithmName)
+        public DagNode(byte[]? data, IEnumerable<IMerkleLink>? links = null, string hashAlgorithm = MultiHash.DefaultAlgorithmName)
         {
-            this.DataBytes = data ?? (new byte[0]);
-            this.Links = (links ?? (new DagLink[0]))
+            this.DataBytes = data ?? Array.Empty<byte>();
+            this.Links = (links ?? Array.Empty<DagLink>())
                 .OrderBy(link => link.Name ?? "");
             this.hashAlgorithm = hashAlgorithm;
         }
@@ -73,11 +73,11 @@ namespace Ipfs
 
         /// <inheritdoc />
         [DataMember]
-        public IEnumerable<IMerkleLink> Links { get; private set; }
+        public IEnumerable<IMerkleLink> Links { get; private set; } = Enumerable.Empty<IMerkleLink>();
 
         /// <inheritdoc />
         [DataMember]
-        public byte[] DataBytes { get; private set; }
+        public byte[] DataBytes { get; private set; } = Array.Empty<byte>();
 
         /// <inheritdoc />
         public Stream DataStream
@@ -96,10 +96,7 @@ namespace Ipfs
         {
             get
             {
-                if (!size.HasValue)
-                {
-                    ComputeSize();
-                }
+                size ??= ComputeSize();
                 return size.Value;
             }
         }
@@ -110,19 +107,13 @@ namespace Ipfs
         {
             get
             {
-                if (id == null)
-                {
-                   ComputeHash();
-                }
+                id ??= ComputeHash();
                 return id;
             }
             set
             {
                 id = value;
-                if (id != null)
-                {
-                    hashAlgorithm = id.Hash.Algorithm.Name;
-                }
+                hashAlgorithm = id.Hash.Algorithm.Name;
             }
         }
 
@@ -237,9 +228,6 @@ namespace Ipfs
         /// </param>
         public void Write(CodedOutputStream stream)
         {
-            if (stream == null)
-                throw new ArgumentNullException("stream");
-
             foreach (var link in Links.Select(l => new DagLink(l)))
             {
                 using (var linkStream = new MemoryStream())
@@ -293,8 +281,7 @@ namespace Ipfs
                 }
             }
 
-            if (DataBytes == null)
-                DataBytes = new byte[0];
+            DataBytes ??= Array.Empty<byte>();
             Links = links.ToArray();
         }
 
@@ -313,25 +300,24 @@ namespace Ipfs
             }
         }
 
-        void ComputeHash()
+        private MultiHash ComputeHash()
         {
             using (var ms = new MemoryStream())
             {
                 Write(ms);
                 size = ms.Position;
                 ms.Position = 0;
-                id = MultiHash.ComputeHash(ms, hashAlgorithm);
+                return MultiHash.ComputeHash(ms, hashAlgorithm);
             }
         }
 
-        void ComputeSize()
+        private long ComputeSize()
         {
             using (var ms = new MemoryStream())
             {
                 Write(ms);
-                size = ms.Position;
+                return ms.Position;
             }
         }
     }
-
 }

--- a/src/IMerkleLink.cs
+++ b/src/IMerkleLink.cs
@@ -18,7 +18,7 @@ namespace Ipfs
         ///   name;
         ///   </note>
         /// </remarks>
-        string Name { get; }
+        string? Name { get; }
 
         /// <summary>
         ///   The unique ID of the link.

--- a/src/IpfsCore.csproj
+++ b/src/IpfsCore.csproj
@@ -4,9 +4,7 @@
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <AssemblyName>IpfsShipyard.Ipfs.Core</AssemblyName>
     <RootNamespace>Ipfs</RootNamespace>
-    <langversion>10.0</langversion>
     <DebugType>portable</DebugType>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- https://semver.org/spec/v2.0.0.html -->
     <Version>0.0.4</Version>

--- a/src/MultiAddress.cs
+++ b/src/MultiAddress.cs
@@ -155,7 +155,7 @@ namespace Ipfs
             {
                 var protocol = Protocols
                     .LastOrDefault(p => p.Name == "ipfs" || p.Name == "p2p");
-                if (protocol == null)
+                if (protocol is null || protocol.Value is null)
                 {
                     throw new Exception($"'{this}' is missing the peer ID. Add the 'ipfs' or 'p2p' protocol.");
                 }
@@ -344,7 +344,7 @@ namespace Ipfs
                 int c;
                 while (-1 != (c = stream.Read()) && c != '/')
                     name.Append((char)c);
-                
+
                 if (name.Length == 0)
                     break;
 
@@ -377,7 +377,7 @@ namespace Ipfs
         public override bool Equals(object obj)
         {
             var that = obj as MultiAddress;
-            return (that == null)
+            return (that is null)
                 ? false
                 : this.Equals(that);
         }
@@ -400,7 +400,7 @@ namespace Ipfs
         /// <summary>
         ///   Value equality.
         /// </summary>
-        public static bool operator ==(MultiAddress a, MultiAddress b)
+        public static bool operator ==(MultiAddress? a, MultiAddress? b)
         {
             if (object.ReferenceEquals(a, b)) return true;
             if (a is null) return false;
@@ -412,13 +412,9 @@ namespace Ipfs
         /// <summary>
         ///   Value inequality.
         /// </summary>
-        public static bool operator !=(MultiAddress a, MultiAddress b)
+        public static bool operator !=(MultiAddress? a, MultiAddress? b)
         {
-            if (object.ReferenceEquals(a, b)) return false;
-            if (a is null) return true;
-            if (b is null) return true;
-
-            return !a.Equals(b);
+            return !(a == b);
         }
 
         /// <summary>
@@ -472,7 +468,7 @@ namespace Ipfs
         /// <returns>
         ///   <b>null</b> if the string cannot be parsed; otherwise a <see cref="MultiAddress"/>.
         /// </returns>
-        public static MultiAddress TryCreate(string s)
+        public static MultiAddress? TryCreate(string s)
         {
             try
             {
@@ -494,7 +490,7 @@ namespace Ipfs
         /// <returns>
         ///   <b>null</b> if the bytes cannot be parsed; otherwise a <see cref="MultiAddress"/>.
         /// </returns>
-        public static MultiAddress TryCreate(byte[] bytes)
+        public static MultiAddress? TryCreate(byte[] bytes)
         {
             try
             {
@@ -512,7 +508,7 @@ namespace Ipfs
         /// <remarks>
         ///   The JSON is just a single string value.
         /// </remarks>
-        class Json : JsonConverter
+        private sealed class Json : JsonConverter
         {
             public override bool CanConvert(Type objectType)
             {
@@ -520,20 +516,17 @@ namespace Ipfs
             }
             public override bool CanRead => true;
             public override bool CanWrite => true;
-            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
             {
                 var ma = value as MultiAddress;
                 writer.WriteValue(ma?.ToString());
             }
 
-            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
             {
                 var s = reader.Value as string;
-                return s == null ? null : new MultiAddress(s);
+                return s is null ? null : new MultiAddress(s);
             }
         }
-
-
     }
-
 }

--- a/src/MultiBase.cs
+++ b/src/MultiBase.cs
@@ -64,11 +64,6 @@ namespace Ipfs
         /// </exception>
         public static string Encode(byte[] bytes, string algorithmName = DefaultAlgorithmName)
         {
-            if (bytes == null)
-            {
-                throw new ArgumentNullException("bytes");
-            }
-
             var alg = GetAlgorithm(algorithmName);
             return alg.Code + alg.Encode(bytes);
         }
@@ -90,11 +85,11 @@ namespace Ipfs
         {
             if (string.IsNullOrWhiteSpace(s))
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             }
 
             MultiBaseAlgorithm.Codes.TryGetValue(s[0], out MultiBaseAlgorithm alg);
-            if (alg == null)
+            if (alg is null)
             {
                 throw new FormatException($"MultiBase '{s}' is invalid. The code is not registered.");
             }

--- a/src/MultiCodec.cs
+++ b/src/MultiCodec.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Ipfs.Registry;
 using Google.Protobuf;
 
@@ -45,10 +41,7 @@ namespace Ipfs
         {
             var code = stream.ReadVarint32();
             Codec.Codes.TryGetValue(code, out Codec codec);
-            if (codec == null)
-            {
-                codec = Codec.Register($"codec-{code}", code);
-            }
+            codec ??= Codec.Register($"codec-{code}", code);
             return codec;
         }
 
@@ -90,14 +83,11 @@ namespace Ipfs
         /// </exception>
         public static void WriteMultiCodec(this Stream stream, string name)
         {
-            Codec.Names.TryGetValue(name, out Codec codec);
-            if (codec == null)
+            if (!Codec.Names.TryGetValue(name, out Codec codec))
             {
                 throw new KeyNotFoundException($"Codec '{name}' is not registered.");
             }
             stream.WriteVarint(codec.Code);
         }
-
-
     }
 }

--- a/src/NamedContent.cs
+++ b/src/NamedContent.cs
@@ -16,7 +16,7 @@ namespace Ipfs
         /// <value>
         ///   Typically <c>/ipns/...</c>.
         /// </value>
-        public string NamePath { get; set; }
+        public string? NamePath { get; set; }
 
         /// <summary>
         ///   Path to the content.
@@ -24,6 +24,6 @@ namespace Ipfs
         /// <value>
         ///   Typically <c>/ipfs/...</c>.
         /// </value>
-        public string ContentPath { get; set; }
+        public string? ContentPath { get; set; }
     }
 }

--- a/src/NetworkProtocol.cs
+++ b/src/NetworkProtocol.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using Google.Protobuf;
 using System.Globalization;
-using Org.BouncyCastle.Asn1.IsisMtt.Ocsp;
 
 namespace Ipfs
 {
@@ -69,9 +66,9 @@ namespace Ipfs
             var protocol = new T();
 
             if (Names.ContainsKey(protocol.Name))
-                throw new ArgumentException(string.Format("The IPFS network protocol '{0}' is already defined.", protocol.Name));
+                throw new ArgumentException($"The IPFS network protocol '{protocol.Name}' is already defined.");
             if (Codes.ContainsKey(protocol.Code))
-                throw new ArgumentException(string.Format("The IPFS network protocol code ({0}) is already defined.", protocol.Code));
+                throw new ArgumentException($"The IPFS network protocol code ({protocol.Code}) is already defined.");
 
             Names.Add(protocol.Name, typeof(T));
             Codes.Add(protocol.Code, typeof(T));
@@ -88,9 +85,9 @@ namespace Ipfs
             var protocol = new T();
 
             if (Names.ContainsKey(protocol.Name))
-                throw new ArgumentException(string.Format("The IPFS network protocol '{0}' is already defined.", protocol.Name));
+                throw new ArgumentException($"The IPFS network protocol '{protocol.Name}' is already defined.");
             if (!Codes.ContainsKey(protocol.Code))
-                throw new ArgumentException(string.Format("The IPFS network protocol code ({0}) is not defined.", protocol.Code));
+                throw new ArgumentException($"The IPFS network protocol code ({protocol.Code}) is not defined.");
 
             Names.Add(protocol.Name, typeof(T));
         }
@@ -111,7 +108,7 @@ namespace Ipfs
         /// <remarks>
         ///   For tcp and udp this is the port number.  This can be <b>null</b> as is the case for http and https.
         /// </remarks>
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
         /// <summary>
         ///   Writes the binary representation to the specified <see cref="Stream"/>.
@@ -135,7 +132,7 @@ namespace Ipfs
         /// </remarks>
         public virtual void WriteValue(TextWriter stream)
         {
-            if (Value != null)
+            if (Value is not null)
             {
                 stream.Write('/');
                 stream.Write(Value);
@@ -186,7 +183,6 @@ namespace Ipfs
                 return s.ToString();
             }
         }
-
     }
 
     class TcpNetworkProtocol : NetworkProtocol
@@ -240,14 +236,14 @@ namespace Ipfs
 
     abstract class IpNetworkProtocol : NetworkProtocol
     {
-        public IPAddress Address { get; set; }
+        public IPAddress? Address { get; set; }
         public override void ReadValue(TextReader stream)
         {
             base.ReadValue(stream);
             try
             {
                 // Remove the scope id.
-                int i = Value.LastIndexOf('%');
+                int i = Value!.LastIndexOf('%');
                 if (i != -1)
                     Value = Value.Substring(0, i);
 
@@ -261,18 +257,18 @@ namespace Ipfs
         public override void WriteValue(TextWriter stream)
         {
             stream.Write('/');
-            stream.Write(Address.ToString());
+            stream.Write(Address?.ToString());
         }
         public override void WriteValue(CodedOutputStream stream)
         {
-            var ip = Address.GetAddressBytes();
+            var ip = Address?.GetAddressBytes() ?? Array.Empty<byte>();
             stream.WriteSomeBytes(ip);
         }
     }
 
     class Ipv4NetworkProtocol : IpNetworkProtocol
     {
-        static int AddressSize = IPAddress.Any.GetAddressBytes().Length;
+        private static readonly int AddressSize = IPAddress.Any.GetAddressBytes().Length;
 
         public override string Name => "ip4";
         public override uint Code => 4;
@@ -280,7 +276,7 @@ namespace Ipfs
         public override void ReadValue(TextReader stream)
         {
             base.ReadValue(stream);
-            if (Address.AddressFamily != AddressFamily.InterNetwork)
+            if (Address!.AddressFamily != AddressFamily.InterNetwork)
                 throw new FormatException(string.Format("'{0}' is not a valid IPv4 address.", Value));
         }
         public override void ReadValue(CodedInputStream stream)
@@ -289,12 +285,11 @@ namespace Ipfs
             Address = new IPAddress(a);
             Value = Address.ToString();
         }
-
     }
 
     class Ipv6NetworkProtocol : IpNetworkProtocol
     {
-        static int AddressSize = IPAddress.IPv6Any.GetAddressBytes().Length;
+        private static readonly int AddressSize = IPAddress.IPv6Any.GetAddressBytes().Length;
 
         public override string Name => "ip6";
         public override uint Code => 41;
@@ -302,7 +297,7 @@ namespace Ipfs
         public override void ReadValue(TextReader stream)
         {
             base.ReadValue(stream);
-            if (Address.AddressFamily != AddressFamily.InterNetworkV6)
+            if (Address!.AddressFamily != AddressFamily.InterNetworkV6)
                 throw new FormatException(string.Format("'{0}' is not a valid IPv6 address.", Value));
         }
         public override void ReadValue(CodedInputStream stream)
@@ -315,14 +310,14 @@ namespace Ipfs
 
     class P2pNetworkProtocol : NetworkProtocol
     {
-        public MultiHash MultiHash { get; private set; }
+        public MultiHash? MultiHash { get; private set; }
         public override string Name => "p2p";
         public override uint Code => 421;
 
         public override void ReadValue(TextReader stream)
         {
             base.ReadValue(stream);
-            MultiHash = new MultiHash(Value);
+            MultiHash = new MultiHash(Value!);
         }
 
         public override void ReadValue(CodedInputStream stream)
@@ -334,7 +329,7 @@ namespace Ipfs
 
         public override void WriteValue(CodedOutputStream stream)
         {
-            var bytes = MultiHash.ToArray();
+            var bytes = MultiHash?.ToArray() ?? Array.Empty<byte>();
             stream.WriteLength(bytes.Length);
             stream.WriteSomeBytes(bytes); 
         }
@@ -347,7 +342,7 @@ namespace Ipfs
 
     class OnionNetworkProtocol : NetworkProtocol
     {
-        public byte[] Address { get; private set; }
+        public byte[] Address { get; private set; } = Array.Empty<byte>();
         public UInt16 Port { get; private set; }
         public override string Name => "onion";
         public override uint Code => 444;
@@ -355,11 +350,11 @@ namespace Ipfs
         public override void ReadValue(TextReader stream)
         {
             base.ReadValue(stream);
-            var parts = Value.Split(':');
+            var parts = Value!.Split(':');
             if (parts.Length != 2)
-                throw new FormatException(string.Format("'{0}' is not a valid onion address, missing the port number.", Value));
+                throw new FormatException($"'{Value}' is not a valid onion address, missing the port number.");
             if (parts[0].Length != 16)
-                throw new FormatException(string.Format("'{0}' is not a valid onion address.", Value));
+                throw new FormatException($"'{Value}' is not a valid onion address.");
             try
             {
                 Port = UInt16.Parse(parts[1]);
@@ -372,6 +367,7 @@ namespace Ipfs
                 throw new FormatException(string.Format("'{0}' is not a valid onion address, invalid port number.", Value));
             Address = parts[0].ToUpperInvariant().FromBase32();
         }
+
         public override void ReadValue(CodedInputStream stream)
         {
             Address = stream.ReadSomeBytes(10);
@@ -493,7 +489,7 @@ namespace Ipfs
 
     abstract class DomainNameNetworkProtocol : NetworkProtocol
     {
-        public string DomainName { get; set; }
+        public string? DomainName { get; set; }
         public override void ReadValue(TextReader stream)
         {
             base.ReadValue(stream);
@@ -508,7 +504,7 @@ namespace Ipfs
         public override void WriteValue(TextWriter stream)
         {
             stream.Write('/');
-            stream.Write(DomainName.ToString());
+            stream.Write(DomainName?.ToString());
         }
         public override void WriteValue(CodedOutputStream stream)
         {
@@ -572,5 +568,4 @@ namespace Ipfs
             stream.WriteSomeBytes(bytes);
         }
     }
-
 }

--- a/src/Peer.cs
+++ b/src/Peer.cs
@@ -13,8 +13,8 @@ namespace Ipfs
     /// </remarks>
     public class Peer : IEquatable<Peer>
     {
-        static MultiAddress[] noAddress = new MultiAddress[0];
-        const string unknown = "unknown/0.0";
+        private static readonly MultiAddress[] noAddress = new MultiAddress[0];
+        private const string unknown = "unknown/0.0";
 
         /// <summary>
         ///   Universally unique identifier.
@@ -24,7 +24,7 @@ namespace Ipfs
         ///   <see cref="PublicKey"/>.
         /// </value>
         /// <seealso href="https://github.com/libp2p/specs/pull/100"/>
-        public MultiHash Id { get; set; }
+        public MultiHash? Id { get; set; }
 
         /// <summary>
         ///   The public key of the node.
@@ -37,7 +37,7 @@ namespace Ipfs
         ///   a type and the DER encoding of the PKCS Subject Public Key Info.
         /// </remarks>
         /// <seealso href="https://tools.ietf.org/html/rfc5280#section-4.1.2.7"/>
-        public string PublicKey { get; set; }
+        public string? PublicKey { get; set; }
 
         /// <summary>
         ///   The multiple addresses of the node.
@@ -77,7 +77,7 @@ namespace Ipfs
         /// <value>
         ///   <b>null</b> when the peer is not connected to.
         /// </value>
-        public MultiAddress ConnectedAddress { get; set; }
+        public MultiAddress? ConnectedAddress { get; set; }
 
         /// <summary>
         /// The round-trip time it takes to get data from the peer.
@@ -99,9 +99,9 @@ namespace Ipfs
         /// </remarks>
         public bool IsValid()
         {
-            if (Id == null)
+            if (Id is null)
                 return false;
-            if (PublicKey != null && !Id.Matches(Convert.FromBase64String(PublicKey)))
+            if (PublicKey is not null && !Id.Matches(Convert.FromBase64String(PublicKey)))
                 return false;
 
             return true;
@@ -117,9 +117,9 @@ namespace Ipfs
         public override bool Equals(object obj)
         {
             var that = obj as Peer;
-            return (that == null)
+            return (that is null)
                 ? false
-               : this.Equals(that);
+                : this.Equals(that);
         }
 
         /// <inheritdoc />
@@ -131,7 +131,7 @@ namespace Ipfs
         /// <summary>
         ///   Value equality.
         /// </summary>
-        public static bool operator ==(Peer a, Peer b)
+        public static bool operator ==(Peer? a, Peer? b)
         {
             if (object.ReferenceEquals(a, b)) return true;
             if (a is null) return false;
@@ -143,7 +143,7 @@ namespace Ipfs
         /// <summary>
         ///   Value inequality.
         /// </summary>
-        public static bool operator !=(Peer a, Peer b)
+        public static bool operator !=(Peer? a, Peer? b)
         {
             return !(a == b);
         }
@@ -156,7 +156,7 @@ namespace Ipfs
         /// </returns>
         public override string ToString()
         {
-            return Id == null ? string.Empty : Id.ToBase58();
+            return Id is null ? string.Empty : Id.ToBase58();
         }
 
         /// <summary>

--- a/src/ProtobufHelper.cs
+++ b/src/ProtobufHelper.cs
@@ -1,21 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Google.Protobuf;
 
 namespace Ipfs
 {
     static class ProtobufHelper
     {
-        static MethodInfo writeRawBytes = typeof(CodedOutputStream)
+        private static readonly MethodInfo writeRawBytes = typeof(CodedOutputStream)
             .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
             .Single(m =>
                 m.Name == "WriteRawBytes" && m.GetParameters().Count() == 1
             );
-        static MethodInfo readRawBytes = typeof(CodedInputStream)
+        private static readonly MethodInfo readRawBytes = typeof(CodedInputStream)
             .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
             .Single(m =>
                 m.Name == "ReadRawBytes"

--- a/src/Registry/Codec.cs
+++ b/src/Registry/Codec.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Ipfs.Registry
 {
@@ -63,7 +62,7 @@ namespace Ipfs.Registry
         /// <value>
         ///   A unique name.
         /// </value>
-        public string Name { get; private set; }
+        public string Name { get; private set; } = string.Empty;
 
         /// <summary>
         ///   The IPFS code assigned to the codec.
@@ -112,7 +111,7 @@ namespace Ipfs.Registry
         public static Codec Register(string name, int code)
         {
             if (string.IsNullOrWhiteSpace(name))
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             if (Names.ContainsKey(name))
                 throw new ArgumentException(string.Format("The IPFS codec name '{0}' is already defined.", name));
             if (Codes.ContainsKey(code))

--- a/src/Registry/HashingAlgorithm.cs
+++ b/src/Registry/HashingAlgorithm.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using Ipfs.Cryptography;
 using System.Security.Cryptography;
 using BC = Org.BouncyCastle.Crypto.Digests;
-
 
 namespace Ipfs.Registry
 {
@@ -82,7 +80,7 @@ namespace Ipfs.Registry
         /// <value>
         ///   A unique name.
         /// </value>
-        public string Name { get; private set; }
+        public string Name { get; private set; } = string.Empty;
 
         /// <summary>
         ///   The IPFS number assigned to the hashing algorithm.
@@ -105,7 +103,7 @@ namespace Ipfs.Registry
         ///   Returns a cryptographic hash algorithm that can compute
         ///   a hash (digest).
         /// </summary>
-        public Func<HashAlgorithm> Hasher { get; private set; }
+        public Func<HashAlgorithm> Hasher { get; private set; } = () => throw new NotImplementedException();
 
         /// <summary>
         ///   Use <see cref="Register"/> to create a new instance of a <see cref="HashingAlgorithm"/>.
@@ -141,16 +139,15 @@ namespace Ipfs.Registry
         /// <returns>
         ///   A new <see cref="HashingAlgorithm"/>.
         /// </returns>
-        public static HashingAlgorithm Register(string name, int code, int digestSize, Func<HashAlgorithm> hasher = null)
+        public static HashingAlgorithm Register(string name, int code, int digestSize, Func<HashAlgorithm>? hasher = null)
         {
             if (string.IsNullOrWhiteSpace(name))
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             if (Names.ContainsKey(name))
-                throw new ArgumentException(string.Format("The IPFS hashing algorithm '{0}' is already defined.", name));
+                throw new ArgumentException($"The IPFS hashing algorithm '{name}' is already defined.");
             if (Codes.ContainsKey(code))
-                throw new ArgumentException(string.Format("The IPFS hashing algorithm code 0x{0:x2} is already defined.", code));
-            if (hasher == null)
-                hasher = () => { throw new NotImplementedException(string.Format("The IPFS hashing algorithm '{0}' is not implemented.", name)); };
+                throw new ArgumentException($"The IPFS hashing algorithm code 0x{code:x2} is already defined.");
+            hasher ??= () => throw new NotImplementedException($"The IPFS hashing algorithm '{name}' is not implemented.");
 
             var a = new HashingAlgorithm
             {
@@ -180,13 +177,13 @@ namespace Ipfs.Registry
         public static HashingAlgorithm RegisterAlias(string alias, string name)
         {
             if (string.IsNullOrWhiteSpace(alias))
-                throw new ArgumentNullException("alias");
+                throw new ArgumentNullException(nameof(alias));
             if (Names.ContainsKey(alias))
-                throw new ArgumentException(string.Format("The IPFS hashing algorithm '{0}' is already defined and cannot be used as an alias.", alias));
+                throw new ArgumentException($"The IPFS hashing algorithm '{alias}' is already defined and cannot be used as an alias.");
             if (string.IsNullOrWhiteSpace(name))
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             if (!Names.TryGetValue(name, out HashingAlgorithm existing))
-                throw new ArgumentException(string.Format("The IPFS hashing algorithm '{0}' is not defined.", name));
+                throw new ArgumentException($"The IPFS hashing algorithm '{name}' is not defined.");
 
             var a = new HashingAlgorithm
             {

--- a/src/Registry/MultiBaseAlgorithm .cs
+++ b/src/Registry/MultiBaseAlgorithm .cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Ipfs.Registry
 {
@@ -91,7 +90,7 @@ namespace Ipfs.Registry
         /// <value>
         ///   A unique name.
         /// </value>
-        public string Name { get; private set; }
+        public string Name { get; private set; } = string.Empty;
 
         /// <summary>
         ///   The IPFS code assigned to the algorithm.
@@ -104,12 +103,12 @@ namespace Ipfs.Registry
         /// <summary>
         ///   Returns a function that can return a string from a byte array.
         /// </summary>
-        public Func<byte[], string> Encode { get; private set; }
+        public Func<byte[], string> Encode { get; private set; } = _ => throw new NotImplementedException();
 
         /// <summary>
         ///   Returns a function that can return a byte array from a string.
         /// </summary>
-        public Func<string, byte[]> Decode { get; private set; }
+        public Func<string, byte[]> Decode { get; private set; } = _ => throw new NotImplementedException();
 
         /// <summary>
         ///   Use <see cref="Register"/> to create a new instance of a <see cref="MultiBaseAlgorithm"/>.
@@ -147,23 +146,19 @@ namespace Ipfs.Registry
         ///   A new <see cref="MultiBaseAlgorithm"/>.
         /// </returns>
         public static MultiBaseAlgorithm Register(
-            string name, char code,
-            Func<byte[], string> encode = null,
-            Func<string, byte[]> decode = null)
+            string name,
+            char code,
+            Func<byte[], string>? encode = null,
+            Func<string, byte[]>? decode = null)
         {
             if (string.IsNullOrWhiteSpace(name))
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             if (Names.ContainsKey(name))
-                throw new ArgumentException(string.Format("The IPFS multi-base algorithm name '{0}' is already defined.", name));
+                throw new ArgumentException($"The IPFS multi-base algorithm name '{name}' is already defined.");
             if (Codes.ContainsKey(code))
-                throw new ArgumentException(string.Format("The IPFS multi-base algorithm code '{0}' is already defined.", code));
-            if (encode == null) {
-                encode = (bytes) => { throw new NotImplementedException(string.Format("The IPFS encode multi-base algorithm '{0}' is not implemented.", name)); };
-            }
-            if (decode == null)
-            {
-                decode = (s) => { throw new NotImplementedException(string.Format("The IPFS decode multi-base algorithm '{0}' is not implemented.", name)); };
-            }
+                throw new ArgumentException($"The IPFS multi-base algorithm code '{code}' is already defined.");
+            encode ??= bytes => throw new NotImplementedException($"The IPFS encode multi-base algorithm '{name}' is not implemented.");
+            decode ??= s => throw new NotImplementedException($"The IPFS decode multi-base algorithm '{name}' is not implemented.");
 
             var a = new MultiBaseAlgorithm
             {

--- a/test/CidTest.cs
+++ b/test/CidTest.cs
@@ -255,8 +255,8 @@ namespace Ipfs
             var a0 = Cid.Decode("zb2rhj7crUKTQYRGCRATFaQ6YFLTde2YzdqbbhAASkL9uRDXn");
             var a1 = Cid.Decode("zb2rhj7crUKTQYRGCRATFaQ6YFLTde2YzdqbbhAASkL9uRDXn");
             var b = Cid.Decode("QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L5");
-            Cid c = null;
-            Cid d = null;
+            Cid? c = null;
+            Cid? d = null;
 
             Assert.IsTrue(c == d);
             Assert.IsFalse(c == b);
@@ -394,14 +394,14 @@ namespace Ipfs
 
         class CidAndX
         {
-            public Cid Cid;
+            public Cid? Cid;
             public int X;
         }
 
         [TestMethod]
         public void JsonSerialization()
         {
-            Cid a = "QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4";
+            Cid? a = "QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4";
             string json = JsonConvert.SerializeObject(a);
             Assert.AreEqual($"\"{a.Encode()}\"", json);
             var b = JsonConvert.DeserializeObject<Cid>(json);
@@ -415,13 +415,15 @@ namespace Ipfs
             var x = new CidAndX { Cid = "QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4", X = 42 };
             json = JsonConvert.SerializeObject(x);
             var y = JsonConvert.DeserializeObject<CidAndX>(json);
-            Assert.AreEqual(x.Cid, y.Cid);
+            Assert.IsNotNull(y);
+            Assert.AreEqual(x.Cid, y!.Cid);
             Assert.AreEqual(x.X, y.X);
 
             x.Cid = null;
             json = JsonConvert.SerializeObject(x);
             y = JsonConvert.DeserializeObject<CidAndX>(json);
-            Assert.AreEqual(x.Cid, y.Cid);
+            Assert.IsNotNull(y);
+            Assert.AreEqual(x.Cid, y!.Cid);
             Assert.AreEqual(x.X, y.X);
         }
 

--- a/test/Cryptography/HashingTest.cs
+++ b/test/Cryptography/HashingTest.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Text;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ipfs.Cryptography
@@ -13,12 +10,12 @@ namespace Ipfs.Cryptography
 
         class TestVector
         {
-            public string Algorithm { get; set; }
-            public string Input { get; set; }
-            public string Digest { get; set; }
+            public string? Algorithm { get; set; }
+            public string? Input { get; set; }
+            public string? Digest { get; set; }
         }
 
-        TestVector[] TestVectors = new TestVector[]
+        readonly TestVector[] TestVectors = new TestVector[]
         {
             new TestVector
             {
@@ -137,8 +134,8 @@ namespace Ipfs.Cryptography
             foreach (var v in TestVectors)
             {
                 var actual = MultiHash
-                    .GetHashAlgorithm(v.Algorithm)
-                    .ComputeHash(v.Input.ToHexBuffer());
+                    .GetHashAlgorithm(v.Algorithm!)
+                    .ComputeHash(v.Input!.ToHexBuffer());
                 Assert.AreEqual(v.Digest, actual.ToHexString(), $"{v.Algorithm} for '{v.Input}'");
             }
         }

--- a/test/DagLinkTest.cs
+++ b/test/DagLinkTest.cs
@@ -37,7 +37,6 @@ namespace Ipfs
         {
             var encoded = "0a22122023dca2a7429612378554b0bb5b85012dec00a17cc2c673f17d2b76a50b839cd51201611803";
             var link = new DagLink("a", "QmQke7LGtfu3GjFP3AnrP8vpEepQ6C5aJSALKAq653bkRi", 3);
-            var x = link.ToArray();
             Assert.AreEqual(encoded, link.ToArray().ToHexString());
         }
 
@@ -46,7 +45,6 @@ namespace Ipfs
         {
             var encoded = "0a22122023dca2a7429612378554b0bb5b85012dec00a17cc2c673f17d2b76a50b839cd512001803";
             var link = new DagLink("", "QmQke7LGtfu3GjFP3AnrP8vpEepQ6C5aJSALKAq653bkRi", 3);
-            var x = link.ToArray();
             Assert.AreEqual(encoded, link.ToArray().ToHexString());
         }
 
@@ -55,15 +53,7 @@ namespace Ipfs
         {
             var encoded = "0a22122023dca2a7429612378554b0bb5b85012dec00a17cc2c673f17d2b76a50b839cd51803";
             var link = new DagLink(null, "QmQke7LGtfu3GjFP3AnrP8vpEepQ6C5aJSALKAq653bkRi", 3);
-            var x = link.ToArray();
             Assert.AreEqual(encoded, link.ToArray().ToHexString());
-        }
-
-        [TestMethod]
-        public void Null_Stream()
-        {
-            ExceptionAssert.Throws(() => new DagLink((CodedInputStream)null));
-            ExceptionAssert.Throws(() => new DagLink((Stream)null));
         }
 
         [TestMethod]

--- a/test/DagNodeTest.cs
+++ b/test/DagNodeTest.cs
@@ -1,11 +1,8 @@
-﻿using Ipfs;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Linq;
 using System.Text;
 using System.IO;
-using Google.Protobuf;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ipfs
 {
@@ -15,7 +12,7 @@ namespace Ipfs
         [TestMethod]
         public void EmptyDAG()
         {
-            var node = new DagNode((byte[]) null);
+            var node = new DagNode((byte[]?) null);
             Assert.AreEqual(0, node.DataBytes.Length);
             Assert.AreEqual(0, node.Links.Count());
             Assert.AreEqual(0, node.Size);
@@ -188,13 +185,6 @@ namespace Ipfs
         }
 
         [TestMethod]
-        public void Null_Stream()
-        {
-            ExceptionAssert.Throws(() => new DagNode((CodedInputStream)null));
-            ExceptionAssert.Throws(() => new DagNode((Stream)null));
-        }
-
-        [TestMethod]
         public void Link_With_CID_V1()
         {
             var data = "124F0A4401551340309ECC489C12D6EB4CC40F50C902F2B4D0ED77EE511A7C7A9BCD3CA86D4CD86F989DD35BC5FF499670DA34255B45B0CFD830E81F605DCF7DC5542E93AE9CD76F120568656C6C6F180B0A020801"
@@ -214,8 +204,8 @@ namespace Ipfs
         [TestMethod]
         public void Setting_Id()
         {
-            var a = new DagNode((byte[])null);
-            var b = new DagNode((byte[])null)
+            var a = new DagNode((byte[]?)null);
+            var b = new DagNode((byte[]?)null)
             {
                 // Wrong hash but allowed.
                 Id = "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1m"

--- a/test/ExceptionAssert.cs
+++ b/test/ExceptionAssert.cs
@@ -10,7 +10,7 @@ namespace Ipfs
     public static class ExceptionAssert
     {
 
-        public static T Throws<T>(Action action, string expectedMessage = null) where T : Exception
+        public static T Throws<T>(Action action, string? expectedMessage = null) where T : Exception
         {
             try
             {
@@ -19,9 +19,9 @@ namespace Ipfs
             catch (AggregateException e)
             {
                 var match = e.InnerExceptions.OfType<T>().FirstOrDefault();
-                if (match != null)
+                if (match is not null)
                 {
-                    if (expectedMessage != null)
+                    if (expectedMessage is not null)
                         Assert.AreEqual(expectedMessage, match.Message, "Wrong exception message.");
                     return match;
                 }
@@ -30,20 +30,19 @@ namespace Ipfs
             }
             catch (T e)
             {
-                if (expectedMessage != null)
+                if (expectedMessage is not null)
                     Assert.AreEqual(expectedMessage, e.Message);
                 return e;
             }
             Assert.Fail("Exception of type {0} should be thrown.", typeof(T));
 
             //  The compiler doesn't know that Assert.Fail will always throw an exception
-            return null;
+            throw new Exception();
         }
 
-        public static Exception Throws(Action action, string expectedMessage = null)
+        public static Exception Throws(Action action, string? expectedMessage = null)
         {
             return Throws<Exception>(action, expectedMessage);
         }
-
     }
 }

--- a/test/MultBaseTest.cs
+++ b/test/MultBaseTest.cs
@@ -28,16 +28,10 @@ namespace Ipfs
         }
 
         [TestMethod]
-        public void Encode_Null_Data_Not_Allowed()
-        {
-            ExceptionAssert.Throws<ArgumentNullException>(() => MultiBase.Encode(null));
-        }
-
-        [TestMethod]
         public void Decode_Bad_Formats()
         {
-            ExceptionAssert.Throws<ArgumentNullException>(() => MultiBase.Decode(null));
-            ExceptionAssert.Throws<ArgumentNullException>(() => MultiBase.Decode(""));
+            ExceptionAssert.Throws<ArgumentNullException>(() => MultiBase.Decode(null!));
+            ExceptionAssert.Throws<ArgumentNullException>(() => MultiBase.Decode(string.Empty));
             ExceptionAssert.Throws<ArgumentNullException>(() => MultiBase.Decode("   "));
 
             ExceptionAssert.Throws<FormatException>(() => MultiBase.Decode("?"));
@@ -48,12 +42,12 @@ namespace Ipfs
 
         class TestVector
         {
-            public string Algorithm { get; set; }
-            public string Input { get; set; }
-            public string Output { get; set; }
+            public string? Algorithm { get; set; }
+            public string? Input { get; set; }
+            public string? Output { get; set; }
         }
 
-        TestVector[] TestVectors = new TestVector[]
+        readonly TestVector[] TestVectors = new TestVector[]
         {
             new TestVector {
                 Algorithm = "base16",
@@ -191,8 +185,8 @@ namespace Ipfs
         {
             foreach (var v in TestVectors)
             {
-                var bytes = Encoding.UTF8.GetBytes(v.Input);
-                var s = MultiBase.Encode(bytes, v.Algorithm);
+                var bytes = Encoding.UTF8.GetBytes(v.Input!);
+                var s = MultiBase.Encode(bytes, v.Algorithm!);
                 Assert.AreEqual(v.Output, s);
                 CollectionAssert.AreEqual(bytes, MultiBase.Decode(s));
             }
@@ -201,7 +195,7 @@ namespace Ipfs
         [TestMethod]
         public void EmptyData()
         {
-            var empty = new byte[0];
+            var empty = Array.Empty<byte>();
             foreach (var alg in MultiBaseAlgorithm.All)
             {
                 var s = MultiBase.Encode(empty, alg.Name);

--- a/test/MultiAddressTest.cs
+++ b/test/MultiAddressTest.cs
@@ -28,7 +28,7 @@ namespace Ipfs
             Assert.AreEqual("ipfs", a.Protocols[2].Name);
             Assert.AreEqual("QmVcSqVEsvm5RR9mBLjwpb2XjFVn5bPdPL69mL8PH45pPC", a.Protocols[2].Value);
 
-            Assert.AreEqual(0, new MultiAddress((string)null).Protocols.Count);
+            Assert.AreEqual(0, new MultiAddress((string)null!).Protocols.Count);
             Assert.AreEqual(0, new MultiAddress("").Protocols.Count);
             Assert.AreEqual(0, new MultiAddress("  ").Protocols.Count);
         }
@@ -57,8 +57,8 @@ namespace Ipfs
             var a0 = new MultiAddress(somewhere);
             var a1 = new MultiAddress(somewhere);
             var b = new MultiAddress(nowhere);
-            MultiAddress c = null;
-            MultiAddress d = null;
+            MultiAddress? c = null;
+            MultiAddress? d = null;
 
             Assert.IsTrue(c == d);
             Assert.IsFalse(c == b);
@@ -313,7 +313,8 @@ namespace Ipfs
         public void TryCreate_FromBytes()
         {
             var good = MultiAddress.TryCreate("/ip4/1.2.3.4/tcp/80");
-            var good1 = MultiAddress.TryCreate(good.ToArray());
+            Assert.IsNotNull(good);
+            var good1 = MultiAddress.TryCreate(good!.ToArray());
             Assert.AreEqual(good, good1);
 
             Assert.IsNull(MultiAddress.TryCreate(new byte[] { 0x7f }));
@@ -326,7 +327,8 @@ namespace Ipfs
             string json = JsonConvert.SerializeObject(a);
             Assert.AreEqual($"\"{a.ToString()}\"", json);
             var b = JsonConvert.DeserializeObject<MultiAddress>(json);
-            Assert.AreEqual(a.ToString(), b.ToString());
+            Assert.IsNotNull(b);
+            Assert.AreEqual(a.ToString(), b!.ToString());
 
             a = null;
             json = JsonConvert.SerializeObject(a);

--- a/test/MultiHashTest.cs
+++ b/test/MultiHashTest.cs
@@ -1,11 +1,9 @@
-using Ipfs.Registry;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.IO;
-using Google.Protobuf;
+using Ipfs.Registry;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 
 namespace Ipfs
@@ -25,22 +23,14 @@ namespace Ipfs
         [TestMethod]
         public void Unknown_Hash_Name()
         {
-            ExceptionAssert.Throws<ArgumentNullException>(() => new MultiHash(null, new byte[0]));
             ExceptionAssert.Throws<ArgumentException>(() => new MultiHash("", new byte[0]));
             ExceptionAssert.Throws<ArgumentException>(() => new MultiHash("md5", new byte[0]));
         }
 
         [TestMethod]
-        public void Write_Null_Stream()
-        {
-            var mh = new MultiHash("QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB");
-            ExceptionAssert.Throws<ArgumentNullException>(() => mh.Write((CodedOutputStream)null));
-        }
-
-        [TestMethod]
         public void Parsing_Unknown_Hash_Number()
         {
-            HashingAlgorithm unknown = null;
+            HashingAlgorithm? unknown = null;
             EventHandler<UnknownHashingAlgorithmEventArgs> unknownHandler = (s, e) => { unknown = e.Algorithm; };
             var ms = new MemoryStream(new byte[] { 0x01, 0x02, 0x0a, 0x0b });
             MultiHash.UnknownHashingAlgorithm += unknownHandler;
@@ -54,7 +44,7 @@ namespace Ipfs
                 Assert.AreEqual(0xa, mh.Digest[0]);
                 Assert.AreEqual(0xb, mh.Digest[1]);
                 Assert.IsNotNull(unknown, "unknown handler not called");
-                Assert.AreEqual("ipfs-1", unknown.Name);
+                Assert.AreEqual("ipfs-1", unknown!.Name);
                 Assert.AreEqual(1, unknown.Code);
                 Assert.AreEqual(2, unknown.DigestSize);
             }
@@ -74,7 +64,6 @@ namespace Ipfs
         [TestMethod]
         public void Invalid_Digest()
         {
-            ExceptionAssert.Throws<ArgumentNullException>(() => new MultiHash("sha1", null));
             ExceptionAssert.Throws<ArgumentException>(() => new MultiHash("sha1", new byte[0]));
             ExceptionAssert.Throws<ArgumentException>(() => new MultiHash("sha1", new byte[21]));
         }
@@ -209,8 +198,8 @@ namespace Ipfs
             var a0 = new MultiHash("QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4");
             var a1 = new MultiHash("QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4");
             var b = new MultiHash("QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L5");
-            MultiHash c = null;
-            MultiHash d = null;
+            MultiHash? c = null;
+            MultiHash? d = null;
 
             Assert.IsTrue(c == d);
             Assert.IsFalse(c == b);
@@ -301,13 +290,13 @@ namespace Ipfs
         }
         class TestVector
         {
-            public string Algorithm { get; set; }
-            public string Input { get; set; }
-            public string Output { get; set; }
+            public string? Algorithm { get; set; }
+            public string? Input { get; set; }
+            public string? Output { get; set; }
             public bool Ignore { get; set; }
         }
 
-        TestVector[] TestVectors = new TestVector[]
+        readonly TestVector[] TestVectors = new TestVector[]
         {
             // From https://github.com/multiformats/js-multihashing-async/blob/master/test/fixtures/encodes.js
             new TestVector {
@@ -415,8 +404,8 @@ namespace Ipfs
             foreach (var v in TestVectors)
             {
                 if (v.Ignore) continue;
-                var bytes = Encoding.UTF8.GetBytes(v.Input);
-                var mh = MultiHash.ComputeHash(bytes, v.Algorithm);
+                var bytes = Encoding.UTF8.GetBytes(v.Input!);
+                var mh = MultiHash.ComputeHash(bytes, v.Algorithm!);
                 Assert.AreEqual(v.Output, mh.ToArray().ToHexString(), v.Algorithm);
             }
         }
@@ -427,10 +416,10 @@ namespace Ipfs
             foreach (var v in TestVectors)
             {
                 if (v.Ignore) continue;
-                var bytes = Encoding.UTF8.GetBytes(v.Input);
+                var bytes = Encoding.UTF8.GetBytes(v.Input!);
                 using (var ms = new MemoryStream(bytes, false))
                 {
-                    var mh = MultiHash.ComputeHash(ms, v.Algorithm);
+                    var mh = MultiHash.ComputeHash(ms, v.Algorithm!);
                     Assert.AreEqual(v.Output, mh.ToArray().ToHexString(), v.Algorithm);
                 }
             }
@@ -477,7 +466,7 @@ namespace Ipfs
         {
             var a = new MultiHash("QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB");
             string json = JsonConvert.SerializeObject(a);
-            Assert.AreEqual($"\"{a.ToString()}\"", json);
+            Assert.AreEqual($"\"{a}\"", json);
             var b = JsonConvert.DeserializeObject<MultiHash>(json);
             Assert.AreEqual(a, b);
 

--- a/test/PeerTest.cs
+++ b/test/PeerTest.cs
@@ -1,20 +1,16 @@
 ﻿using System;
-using System.Text;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.IO;
 
 namespace Ipfs
 {
-
     [TestClass]
     public class PeerTest
     {
         const string marsId = "QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3";
         const string plutoId = "QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM";
         const string marsPublicKey = "CAASogEwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKGUtbRQf+a9SBHFEruNAUatS/tsGUnHuCtifGrlbYPELD3UyyhWf/FYczBCavx3i8hIPEW2jQv4ehxQxi/cg9SHswZCQblSi0ucwTBFr8d40JEiyB9CcapiMdFQxdMgGvXEOQdLz1pz+UPUDojkdKZq8qkkeiBn7KlAoGEocnmpAgMBAAE=";
-        static string marsAddress = "/ip4/10.1.10.10/tcp/29087/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3";
+        const string marsAddress = "/ip4/10.1.10.10/tcp/29087/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3";
 
         [TestMethod]
         public new void ToString()
@@ -91,8 +87,8 @@ namespace Ipfs
             var a0 = new Peer { Id = marsId };
             var a1 = new Peer { Id = marsId };
             var b = new Peer { Id = plutoId };
-            Peer c = null;
-            Peer d = null;
+            Peer? c = null;
+            Peer? d = null;
 
             Assert.IsTrue(c == d);
             Assert.IsFalse(c == b);

--- a/test/Registry/CodecTest.cs
+++ b/test/Registry/CodecTest.cs
@@ -14,7 +14,7 @@ namespace Ipfs.Registry
         [TestMethod]
         public void Bad_Name()
         {
-            ExceptionAssert.Throws<ArgumentNullException>(() => Codec.Register(null, 1));
+            ExceptionAssert.Throws<ArgumentNullException>(() => Codec.Register(null!, 1));
             ExceptionAssert.Throws<ArgumentNullException>(() => Codec.Register("", 1));
             ExceptionAssert.Throws<ArgumentNullException>(() => Codec.Register("   ", 1));
         }

--- a/test/Registry/HashingAlgorithmTest.cs
+++ b/test/Registry/HashingAlgorithmTest.cs
@@ -62,7 +62,7 @@ namespace Ipfs.Registry
         [TestMethod]
         public void HashingAlgorithm_Bad_Name()
         {
-            ExceptionAssert.Throws<ArgumentNullException>(() => HashingAlgorithm.Register(null, 1, 1));
+            ExceptionAssert.Throws<ArgumentNullException>(() => HashingAlgorithm.Register(null!, 1, 1));
             ExceptionAssert.Throws<ArgumentNullException>(() => HashingAlgorithm.Register("", 1, 1));
             ExceptionAssert.Throws<ArgumentNullException>(() => HashingAlgorithm.Register("   ", 1, 1));
         }
@@ -88,7 +88,7 @@ namespace Ipfs.Registry
         [TestMethod]
         public void HashingAlgorithm_Bad_Alias()
         {
-            ExceptionAssert.Throws<ArgumentNullException>(() => HashingAlgorithm.RegisterAlias(null, "sha1"));
+            ExceptionAssert.Throws<ArgumentNullException>(() => HashingAlgorithm.RegisterAlias(null!, "sha1"));
             ExceptionAssert.Throws<ArgumentNullException>(() => HashingAlgorithm.RegisterAlias("", "sha1"));
             ExceptionAssert.Throws<ArgumentNullException>(() => HashingAlgorithm.RegisterAlias("   ", "sha1"));
         }

--- a/test/Registry/MultibaseAlgorithmTest.cs
+++ b/test/Registry/MultibaseAlgorithmTest.cs
@@ -14,7 +14,7 @@ namespace Ipfs.Registry
         [TestMethod]
         public void Bad_Name()
         {
-            ExceptionAssert.Throws<ArgumentNullException>(() => MultiBaseAlgorithm.Register(null, '?'));
+            ExceptionAssert.Throws<ArgumentNullException>(() => MultiBaseAlgorithm.Register(null!, '?'));
             ExceptionAssert.Throws<ArgumentNullException>(() => MultiBaseAlgorithm.Register("", '?'));
             ExceptionAssert.Throws<ArgumentNullException>(() => MultiBaseAlgorithm.Register("   ", '?'));
         }
@@ -64,8 +64,8 @@ namespace Ipfs.Registry
             var alg = MultiBaseAlgorithm.Register("nyi", 'n');
             try
             {
-                ExceptionAssert.Throws<NotImplementedException>(() => alg.Encode(null));
-                ExceptionAssert.Throws<NotImplementedException>(() => alg.Decode(null));
+                ExceptionAssert.Throws<NotImplementedException>(() => alg.Encode(null!));
+                ExceptionAssert.Throws<NotImplementedException>(() => alg.Decode(null!));
             }
             finally
             {


### PR DESCRIPTION
For #19 . Remove some ArgumentNullException where nullability covers it to reduce runtime code (this is a change to public surface area, can be reverted - see changes in unit tests). Some opportunistic code cleanup ahead of #9 .