### PR TITLE
Add .editorconfig and fix issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,223 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = crlf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.cs]
+dotnet_diagnostic.IDE0073.severity = warning
+# file_header_template = Licensed under the MIT License.
+#######################################################################################
+#                             C# code style settings                                  #
+#######################################################################################
+
+# Sort using and Import directives with System.* appearing first
+# Note, to apply using-related settings you have to run "Remove and Sort using" command from the context menu in VS. Formatting a document will not trigger change the usings block.
+dotnet_sort_system_directives_first                                 = true
+dotnet_separate_import_directive_groups                             = false
+
+dotnet_style_readonly_field                                         = true: warning
+
+# Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_field                                = false : warning
+dotnet_style_qualification_for_property                             = false : warning
+dotnet_style_qualification_for_method                               = false : warning
+dotnet_style_qualification_for_event                                = false : warning
+
+# Use language keywords instead of framework type names for type references: i.e. prefer 'int' over 'Int32'
+dotnet_style_predefined_type_for_locals_parameters_members          = true : warning
+# Prefer `int.MaxValue` over `Int32.MaxValue`
+dotnet_style_predefined_type_for_member_access                      = true : warning
+
+# Prefer `private const string foo` over `const string foo`
+dotnet_style_require_accessibility_modifiers                        = for_non_interface_members : warning
+# Prefer modifier order
+csharp_preferred_modifier_order                                     = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# Suggest more modern language features when available
+
+# Prefer object initializers (e.g. `new Foo() { Bar = 42 };`) over property assignment (e.g. `var f = new Foo(); f.Bar = 42;`)
+dotnet_style_object_initializer                                     = true : suggestion
+# Prefer collection initializers (e.g. new List<int>{1,2,3})
+dotnet_style_collection_initializer                                 = true : suggestion
+# Prefer null coalescing (e.g. `x ?? y`) over ternary null checking (e.g. `x != null ? x:y`)
+dotnet_style_coalesce_expression                                    = true : suggestion
+# Prefer null propagation (e.g. `x?.Foo`) over ternary null checking (e.g. `x != null ? x.Foo:null`)
+dotnet_style_null_propagation                                       = true : suggestion
+# Prefer tuple names over ItemN properties
+dotnet_style_explicit_tuple_names                                   = true : suggestion
+
+# Prefer inferred anonymous type member names (e.g. `var anon = new { age, name };`)
+dotnet_style_prefer_inferred_anonymous_type_member_names            = true : suggestion
+
+# Prefer `var` type in declarations for built-in system types like `int`
+csharp_style_var_for_built_in_types                                 = false : silent
+# Prefer `var` type in declarations when the type is explicitly mentioned on the RHS (e.g. `var customer = new Customer();`)
+csharp_style_var_when_type_is_apparent                              = true : suggestion
+# Prefer `var` type in declarations in all other cases
+csharp_style_var_elsewhere                                          = false : silent
+
+# Prefer expression-bodied members for methods when they will be a single line (e.g. `public int GetAge() => this.Age;`)
+csharp_style_expression_bodied_methods                              = false : silent
+# Prefer expression-bodied members for constructors when they will be a single line (e.g. `public int GetAge() => this.Age;`)
+csharp_style_expression_bodied_constructors                         = false : silent
+# Prefer expression-bodied members for operators when they will be a single line (e.g. `public int GetAge() => this.Age;`)
+csharp_style_expression_bodied_operators                            = when_on_single_line : suggestion
+# Prefer expression-bodied members for properties when they will be a single line (e.g. `public int GetAge() => this.Age;`)
+csharp_style_expression_bodied_properties                           = true : suggestion
+# Prefer expression-bodied members for indexers when they will be a single line (e.g. `public int GetAge() => this.Age;`)
+csharp_style_expression_bodied_indexers                             = true : suggestion
+# Prefer expression-bodied members for accessors when they will be a single line (e.g. `public int GetAge() => this.Age;`)
+csharp_style_expression_bodied_accessors                            = true : suggestion
+
+# Prefer pattern matching instead of `is` expressions with type casts
+csharp_style_pattern_matching_over_is_with_cast_check               = true : suggestion
+# Prefer pattern matching instead of `as` expressions with null checks to determine if something is of a particular type
+csharp_style_pattern_matching_over_as_with_null_check               = true : suggestion
+# Prefer `out` variables to be declared inline in the argument list of a method call when possible
+csharp_style_inlined_variable_declaration                           = true : suggestion
+
+# Prefer `default` over `default(T)`
+csharp_prefer_simple_default_expression                             = true : suggestion
+
+# Prefer deconstructed variable declaration
+csharp_style_deconstructed_variable_declaration                     = true : suggestion
+
+# Prefer local functions over anonymous functions
+csharp_style_pattern_local_over_anonymous_function                  = true : suggestion
+
+# TODO: Change to suggestion after switching to C# 7.2
+# Prefer to use `throw` expressions instead of `throw` statements
+csharp_style_throw_expression                                       = false : suggestion
+
+# Prefer MyEvent?.Invoke(); over `var d = MyEvnet; if (d != null) {d();}`
+csharp_style_conditional_delegate_call                              = true : warning
+
+# Prefer curly braces even for one line of code
+csharp_prefer_braces                                                = true : warning
+
+# Prefer foo[42] = 1; over foo[ 42 ] = 1;
+csharp_space_between_square_brackets                                = false : warning
+
+# Do not prefer if (x) DoSomething()
+csharp_preserve_single_line_statements                              = false : warning
+# Prefer { DoSomething(); }
+csharp_preserve_single_line_blocks                                  = true : suggestion
+
+# Prefer var foo = new[] {1, 2, 3} over new[] {1,2,3};
+csharp_space_after_comma                                            = true : suggestion
+
+#######################################################################################
+#                                   Formatting                                        #
+#######################################################################################
+csharp_new_line_before_open_brace                                   = all
+csharp_new_line_before_else                                         = true
+csharp_new_line_before_catch                                        = true
+csharp_new_line_before_finally                                      = true
+csharp_new_line_before_members_in_object_initializers               = true
+csharp_new_line_before_members_in_anonymous_types                   = true
+csharp_new_line_between_query_expression_clauses                    = true
+csharp_indent_case_contents                                         = true
+csharp_indent_switch_labels                                         = true
+csharp_indent_labels                                                = one_less_than_current
+csharp_space_after_cast                                             = false
+csharp_space_after_keywords_in_control_flow_statements              = true
+csharp_space_between_method_declaration_parameter_list_parentheses  = false
+csharp_space_between_method_call_parameter_list_parentheses         = false
+
+csharp_indent_block_contents                                        = true
+csharp_indent_braces                                                = false
+csharp_indent_case_contents_when_block                              = false
+
+csharp_blank_lines_after_using_list                                 = 1
+csharp_blank_lines_inside_namespace                                 = 0
+csharp_blank_lines_after_file_scoped_namespace_directive            = 1
+csharp_blank_lines_inside_type                                      = 1
+csharp_remove_blank_lines_near_braces_in_code                       = true
+
+#######################################################################################
+#                               Naming Conventions                                    #
+#######################################################################################
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity     = warning
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols      = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style        = non_private_static_field_style
+
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds                = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities      = public, protected, internal, protected internal, private protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers              = static
+
+dotnet_naming_style.non_private_static_field_style.capitalization               = pascal_case
+
+# Constants are PascalCase
+dotnet_naming_rule.constants_should_be_pascal_case.severity                     = warning
+dotnet_naming_rule.constants_should_be_pascal_case.symbols                      = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style                        = constant_style
+
+dotnet_naming_symbols.constants.applicable_kinds                                = field, local
+dotnet_naming_symbols.constants.required_modifiers                              = const
+
+dotnet_naming_style.constant_style.capitalization                               = pascal_case
+
+# Static fields are camelCase and start with s_
+dotnet_naming_rule.static_fields_should_be_camel_case.severity                  = warning
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols                   = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style                     = static_field_style
+
+dotnet_naming_symbols.static_fields.applicable_kinds                            = field
+dotnet_naming_symbols.static_fields.required_modifiers                          = static
+# The rule should be enforced only for private fields
+dotnet_naming_symbols.static_fields.applicable_accessibilities                  = private
+
+dotnet_naming_style.static_field_style.capitalization                           = pascal_case
+
+# We don't configure the naming convention for 'async' methods, because it's not possible to enforce the naming
+# convention for task-based methods not marked with the 'async' prefix (like interface members or simplie `Task FooBar() => Baz()`).
+# Instead 'Microsoft.VisualStudio.Threading.Analyzers' (or simpler) analyzers should be used to enforce it.
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity                = warning
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols                 = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style                   = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds                          = field
+# The rule should be enforced only for private fields
+dotnet_naming_symbols.instance_fields.applicable_accessibilities                = private
+
+dotnet_naming_style.instance_field_style.capitalization                         = camel_case
+dotnet_naming_style.instance_field_style.required_prefix                        = _
+
+# Locals, parameters and local functions are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity                         = warning
+dotnet_naming_rule.locals_should_be_camel_case.symbols                          = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style                            = camel_case_style
+
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds                    = parameter, local, local_function
+
+dotnet_naming_style.camel_case_style.capitalization                             = camel_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity                       = warning
+dotnet_naming_rule.members_should_be_pascal_case.symbols                        = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style                          = pascal_case_style
+
+dotnet_naming_symbols.all_members.applicable_kinds                              = *
+
+dotnet_naming_style.pascal_case_style.capitalization                            = pascal_case
+
+# FXCop Roslyn-Based analyzers
+# CA1063: Implement IDisposable Correctly - for pure managed objects use of the Dispose(bool) pattern is unneeded.
+dotnet_diagnostic.CA1063.severity = none
+
+# CA2237: Mark ISerializable types with serializable
+dotnet_diagnostic.CA2237.severity = none
+
+# CA2217: Do not mark enums with FlagsAttribute
+dotnet_diagnostic.CA2217.severity = none
+
+# RA009: Do not use fluent API for preconditions/assertions to avoid runtime overhead.
+dotnet_diagnostic.RA009.severity = warning

--- a/src/Base32z.cs
+++ b/src/Base32z.cs
@@ -1,7 +1,4 @@
 ﻿using SimpleBase;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Ipfs
 {
@@ -14,12 +11,11 @@ namespace Ipfs
     /// <seealso href="https://en.wikipedia.org/wiki/Base32#z-base-32"/>
     public static class Base32z
     {
-        static readonly Base32Alphabet alphabet =
-            new Base32Alphabet("ybndrfg8ejkmcpqxot1uwisza345h769");
+        private static readonly Base32Alphabet Alphabet = new("ybndrfg8ejkmcpqxot1uwisza345h769");
 
         /// <summary>
         ///   The encoder/decoder for z-base-32.
         /// </summary>
-        public static readonly SimpleBase.Base32 Codec = new SimpleBase.Base32(alphabet);
+        public static readonly SimpleBase.Base32 Codec = new(Alphabet);
     }
 }

--- a/src/Base64Url.cs
+++ b/src/Base64Url.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Ipfs
 {

--- a/src/CoreApi/BandwidthData.cs
+++ b/src/CoreApi/BandwidthData.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Ipfs.CoreApi
+﻿namespace Ipfs.CoreApi
 {
     /// <summary>
     ///   The statistics for <see cref="IStatsApi.BandwidthAsync"/>.
@@ -12,22 +8,21 @@ namespace Ipfs.CoreApi
         /// <summary>
         ///   The number of bytes received.
         /// </summary>
-        public ulong TotalIn;
+        public ulong TotalIn { get; set; }
 
         /// <summary>
         ///   The number of bytes sent.
         /// </summary>
-        public ulong TotalOut;
+        public ulong TotalOut { get; set; }
 
         /// <summary>
         ///   TODO
         /// </summary>
-        public double RateIn;
+        public double RateIn { get; set; }
 
         /// <summary>
         ///   TODO
         /// </summary>
-        public double RateOut;
-
+        public double RateOut { get; set; }
     }
 }

--- a/src/CoreApi/BitswapData.cs
+++ b/src/CoreApi/BitswapData.cs
@@ -10,37 +10,37 @@ namespace Ipfs.CoreApi
         /// <summary>
         ///   TODO: Unknown.
         /// </summary>
-        public int ProvideBufLen;
+        public int ProvideBufLen { get; set; }
 
         /// <summary>
         ///   The content that is wanted.
         /// </summary>
-        public IEnumerable<Cid>? Wantlist;
+        public IEnumerable<Cid>? Wantlist { get; set; }
 
         /// <summary>
         ///   The known peers.
         /// </summary>
-        public IEnumerable<MultiHash>? Peers;
+        public IEnumerable<MultiHash>? Peers { get; set; }
 
         /// <summary>
         ///   The number of blocks sent by other peers.
         /// </summary>
-        public ulong BlocksReceived;
+        public ulong BlocksReceived { get; set; }
 
         /// <summary>
         ///   The number of bytes sent by other peers.
         /// </summary>
-        public ulong DataReceived;
+        public ulong DataReceived { get; set; }
 
         /// <summary>
         ///   The number of blocks sent to other peers.
         /// </summary>
-        public ulong BlocksSent;
+        public ulong BlocksSent { get; set; }
 
         /// <summary>
         ///   The number of bytes sent to other peers.
         /// </summary>
-        public ulong DataSent;
+        public ulong DataSent { get; set; }
 
         /// <summary>
         ///   The number of duplicate blocks sent by other peers.
@@ -49,7 +49,7 @@ namespace Ipfs.CoreApi
         ///   A duplicate block is a block that is already stored in the
         ///   local repository.
         /// </remarks>
-        public ulong DupBlksReceived;
+        public ulong DupBlksReceived { get; set; }
 
         /// <summary>
         ///   The number of duplicate bytes sent by other peers.
@@ -58,6 +58,6 @@ namespace Ipfs.CoreApi
         ///   A duplicate block is a block that is already stored in the
         ///   local repository.
         /// </remarks>
-        public ulong DupDataReceived;
+        public ulong DupDataReceived { get; set; }
     }
 }

--- a/src/CoreApi/BitswapLedger.cs
+++ b/src/CoreApi/BitswapLedger.cs
@@ -46,13 +46,7 @@
         ///   A value less than 1 indicates that we are in debt to the 
         ///   <see cref="Peer"/>.
         /// </value>
-        public float DebtRatio
-        {
-            get
-            {
-                return (float)DataSent / (float)(DataReceived + 1); // +1 is to prevent division by zero
-            }
-        }
+        public float DebtRatio => (float)DataSent / (float)(DataReceived + 1); // +1 is to prevent division by zero
 
         /// <summary>
         ///   Determines if we owe the <see cref="Peer"/> some blocks.
@@ -61,6 +55,5 @@
         ///   <b>true</b> if we owe data to the peer; otherwise, <b>false</b>.
         /// </value>
         public bool IsInDebt => DebtRatio < 1;
-
     }
 }

--- a/src/CoreApi/FileStat.cs
+++ b/src/CoreApi/FileStat.cs
@@ -16,12 +16,12 @@ namespace Ipfs.CoreApi
         /// <summary>
         ///   The serialised size (in bytes) of the linked node.
         /// </summary>
-        public Int64 Size { get; set; }
+        public long Size { get; set; }
 
         /// <summary>
         ///   Size of object and its references.
         /// </summary>
-        public Int64 CumulativeSize { get; set; }
+        public long CumulativeSize { get; set; }
 
         /// <summary>
         ///   Determines if the node is a directory (folder).
@@ -52,7 +52,7 @@ namespace Ipfs.CoreApi
         /// <summary>
         ///   The serialised size (in bytes) of the linked node that is local.
         /// </summary>
-        public Int64 SizeLocal { get; set; }
+        public long SizeLocal { get; set; }
 
         /// <summary>
         ///   Reflection of the parameter is-local.

--- a/src/CoreApi/IConfigApi.cs
+++ b/src/CoreApi/IConfigApi.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,7 +23,7 @@ namespace Ipfs.CoreApi
         /// <returns>
         ///   A <see cref="JObject"/> containing the configuration.
         /// </returns>
-        Task<JObject> GetAsync(CancellationToken cancel = default(CancellationToken));
+        Task<JObject> GetAsync(CancellationToken cancel = default);
 
         /// <summary>
         ///   Gets the value of a configuration key.
@@ -45,7 +43,7 @@ namespace Ipfs.CoreApi
         /// <remarks>
         ///   Keys are case sensistive.
         /// </remarks>
-        Task<JToken> GetAsync(string key, CancellationToken cancel = default(CancellationToken));
+        Task<JToken> GetAsync(string key, CancellationToken cancel = default);
 
         /// <summary>
         ///   Adds or replaces a configuration value.
@@ -59,7 +57,7 @@ namespace Ipfs.CoreApi
         /// <param name="cancel">
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
-        Task SetAsync(string key, string value, CancellationToken cancel = default(CancellationToken));
+        Task SetAsync(string key, string value, CancellationToken cancel = default);
 
         /// <summary>
         ///   Adds or replaces a configuration value.
@@ -73,7 +71,7 @@ namespace Ipfs.CoreApi
         /// <param name="cancel">
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
-        Task SetAsync(string key, JToken value, CancellationToken cancel = default(CancellationToken));
+        Task SetAsync(string key, JToken value, CancellationToken cancel = default);
 
         /// <summary>
         ///   Replaces the entire configuration.

--- a/src/CoreApi/IDagApi.cs
+++ b/src/CoreApi/IDagApi.cs
@@ -116,7 +116,7 @@ namespace Ipfs.CoreApi
         ///   the data's <see cref="Cid"/>.
         /// </returns>
         Task<Cid> PutAsync(
-            Object data,
+            object data,
             string contentType = "dag-cbor",
             string multiHash = MultiHash.DefaultAlgorithmName,
             string encoding = MultiBase.DefaultAlgorithmName,

--- a/src/CoreApi/IDhtApi.cs
+++ b/src/CoreApi/IDhtApi.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Ipfs.CoreApi
+﻿namespace Ipfs.CoreApi
 {
     /// <summary>
     ///   Manages the Distributed Hash Table.

--- a/src/CoreApi/IDnsApi.cs
+++ b/src/CoreApi/IDnsApi.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ipfs.CoreApi
@@ -16,7 +13,6 @@ namespace Ipfs.CoreApi
     /// </remarks>
     public interface IDnsApi
     {
-
         /// <summary>
         ///   Resolve a domain name to an IPFS path.
         /// </summary>
@@ -49,7 +45,6 @@ namespace Ipfs.CoreApi
         Task<string> ResolveAsync(
             string name,
             bool recursive = false,
-            CancellationToken cancel = default(CancellationToken)
-            );
+            CancellationToken cancel = default);
     }
 }

--- a/src/CoreApi/IFileSystemApi.cs
+++ b/src/CoreApi/IFileSystemApi.cs
@@ -103,7 +103,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value is
         ///   the contents of the <paramref name="path"/> as a <see cref="string"/>.
         /// </returns>
-        Task<String> ReadAllTextAsync(string path, CancellationToken cancel = default);
+        Task<string> ReadAllTextAsync(string path, CancellationToken cancel = default);
 
         /// <summary>
         ///   Reads an existing IPFS file.

--- a/src/CoreApi/IMfsApi.cs
+++ b/src/CoreApi/IMfsApi.cs
@@ -58,7 +58,9 @@ namespace Ipfs.CoreApi
         /// <remarks>
         ///   Paramter long is ommitted and should always be passed as true in implementation.
         /// </remarks>
+#pragma warning disable IDE1006 // Naming Styles - keep capital U
         Task<IEnumerable<IFileSystemNode>> ListAsync(string path, bool? U = null, CancellationToken cancel = default);
+#pragma warning restore IDE1006 // Naming Styles
 
         /// <summary>
         ///   Make directories in the local mutable namespace.
@@ -110,7 +112,7 @@ namespace Ipfs.CoreApi
         /// <param name="cancel">
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
-        Task<string> ReadFileAsync(string path, Int64? offset = null, Int64? count = null, CancellationToken cancel = default);
+        Task<string> ReadFileAsync(string path, long? offset = null, long? count = null, CancellationToken cancel = default);
 
         /// <summary>
         ///   Remove a file or directory or from MFS.

--- a/src/CoreApi/INameApi.cs
+++ b/src/CoreApi/INameApi.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -45,8 +43,7 @@ namespace Ipfs.CoreApi
             bool resolve = true,
             string key = "self",
             TimeSpan? lifetime = null,
-            CancellationToken cancel = default(CancellationToken)
-            );
+            CancellationToken cancel = default);
 
         /// <summary>
         ///   Publish an IPFS name.
@@ -71,8 +68,7 @@ namespace Ipfs.CoreApi
             Cid id,
             string key = "self",
             TimeSpan? lifetime = null,
-            CancellationToken cancel = default(CancellationToken)
-            );
+            CancellationToken cancel = default);
 
         /// <summary>
         ///   Resolve an IPNS name.
@@ -98,7 +94,6 @@ namespace Ipfs.CoreApi
             string name,
             bool recursive = false,
             bool nocache = false,
-            CancellationToken cancel = default(CancellationToken)
-            );
+            CancellationToken cancel = default);
     }
 }

--- a/src/CoreApi/IPinApi.cs
+++ b/src/CoreApi/IPinApi.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -30,7 +28,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value
         ///   is a sequence of <see cref="Cid"/> that were pinned.
         /// </returns>
-        Task<IEnumerable<Cid>> AddAsync(string path, bool recursive = true, CancellationToken cancel = default(CancellationToken));
+        Task<IEnumerable<Cid>> AddAsync(string path, bool recursive = true, CancellationToken cancel = default);
 
         /// <summary>
         ///   List all the objects pinned to local storage.
@@ -42,7 +40,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value
         ///   is a sequence of <see cref="Cid"/>.
         /// </returns>
-        Task<IEnumerable<Cid>> ListAsync(CancellationToken cancel = default(CancellationToken));
+        Task<IEnumerable<Cid>> ListAsync(CancellationToken cancel = default);
 
         /// <summary>
         ///   Unpin an object.
@@ -61,7 +59,6 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation. The task's value
         ///   is a sequence of <see cref="Cid"/> that were unpinned.
         /// </returns>
-        Task<IEnumerable<Cid>> RemoveAsync(Cid id, bool recursive = true, CancellationToken cancel = default(CancellationToken));
-
+        Task<IEnumerable<Cid>> RemoveAsync(Cid id, bool recursive = true, CancellationToken cancel = default);
     }
 }

--- a/src/CoreApi/IValueStore.cs
+++ b/src/CoreApi/IValueStore.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ipfs.CoreApi
@@ -24,7 +21,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation that returns
         ///   the value of the key as a byte array.
         /// </returns>
-        Task<byte[]> GetAsync(byte[] key, CancellationToken cancel = default(CancellationToken));
+        Task<byte[]> GetAsync(byte[] key, CancellationToken cancel = default);
 
         /// <summary>
         ///   Tries to get the value of a key.
@@ -42,7 +39,7 @@ namespace Ipfs.CoreApi
         ///   A task that represents the asynchronous operation that returns
         ///   <b>true</b> if the key exists; otherwise, <b>false</b>.
         /// </returns>
-        Task<bool> TryGetAsync(byte[] key, out byte[] value, CancellationToken cancel = default(CancellationToken));
+        Task<bool> TryGetAsync(byte[] key, out byte[] value, CancellationToken cancel = default);
 
         /// <summary>
         ///   Put the value of a key.
@@ -59,6 +56,6 @@ namespace Ipfs.CoreApi
         /// <returns>
         ///   A task that represents the asynchronous operation.
         /// </returns>
-        Task PutAsync(byte[] key, out byte[] value, CancellationToken cancel = default(CancellationToken));
+        Task PutAsync(byte[] key, out byte[] value, CancellationToken cancel = default);
     }
 }

--- a/src/CoreApi/MfsWriteOptions.cs
+++ b/src/CoreApi/MfsWriteOptions.cs
@@ -32,7 +32,7 @@ namespace Ipfs.CoreApi
         ///   The default is <b>null</b> and the argument will be omitted.
         ///   If ommitted the offset is zero.
         /// </value>
-        public Int64? Offset { get; set; } = null;
+        public long? Offset { get; set; } = null;
 
         /// <summary>
         ///   Maximum number of bytes to write.
@@ -41,7 +41,7 @@ namespace Ipfs.CoreApi
         ///   The default is <b>null</b> and the argument will be omitted.
         ///   If ommitted, all the data will be written.
         /// </value>
-        public Int64? Count { get; set; } = null;
+        public long? Count { get; set; } = null;
 
         /// <summary>
         ///    Cid version to use.

--- a/src/CoreApi/ObjectStat.cs
+++ b/src/CoreApi/ObjectStat.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Ipfs.CoreApi
+﻿namespace Ipfs.CoreApi
 {
     /// <summary>
     ///   Information on a DAG node.

--- a/src/Cryptography/BouncyDigest.cs
+++ b/src/Cryptography/BouncyDigest.cs
@@ -12,35 +12,34 @@ namespace Ipfs.Cryptography
     /// </remarks>
     internal class BouncyDigest : System.Security.Cryptography.HashAlgorithm
     {
-        Org.BouncyCastle.Crypto.IDigest digest;
+        private readonly Org.BouncyCastle.Crypto.IDigest _digest;
 
         /// <summary>
         ///   Wrap the bouncy castle digest.
         /// </summary>
         public BouncyDigest(Org.BouncyCastle.Crypto.IDigest digest)
         {
-            this.digest = digest;
+            _digest = digest;
         }
 
         /// <inheritdoc/>
         public override void Initialize()
         {
-            digest.Reset();
+            _digest.Reset();
         }
 
         /// <inheritdoc/>
         protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {
-            digest.BlockUpdate(array, ibStart, cbSize);
+            _digest.BlockUpdate(array, ibStart, cbSize);
         }
 
         /// <inheritdoc/>
         protected override byte[] HashFinal()
         {
-            var output = new byte[digest.GetDigestSize()];
-            digest.DoFinal(output, 0);
+            var output = new byte[_digest.GetDigestSize()];
+            _digest.DoFinal(output, 0);
             return output;
         }
     }
 }
- 

--- a/src/Cryptography/DoubleSha256.cs
+++ b/src/Cryptography/DoubleSha256.cs
@@ -5,29 +5,30 @@ namespace Ipfs.Cryptography
 {
     internal class DoubleSha256 : HashAlgorithm
     {
-        private readonly HashAlgorithm digest = SHA256.Create();
-        private byte[]? round1;
+        private readonly HashAlgorithm _digest = SHA256.Create();
+        private byte[]? _round1;
 
         public override void Initialize()
         {
-            digest.Initialize();
-            round1 = null;
+            _digest.Initialize();
         }
 
-        public override int HashSize => digest.HashSize;
+        public override int HashSize => _digest.HashSize;
 
         protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {
-            if (round1 is not null)
+            if (_round1 is not null)
+            {
                 throw new NotSupportedException("Already called.");
+            }
 
-            round1 = digest.ComputeHash(array, ibStart, cbSize);
+            _round1 = _digest.ComputeHash(array, ibStart, cbSize);
         }
 
         protected override byte[] HashFinal()
         {
-            digest.Initialize();
-            return digest.ComputeHash(round1);
+            _digest.Initialize();
+            return _digest.ComputeHash(_round1);
         }
     }
 }

--- a/src/Cryptography/Keccak.cs
+++ b/src/Cryptography/Keccak.cs
@@ -9,6 +9,10 @@
  */
 using System;
 
+#pragma warning disable IDE1006 // Naming Styles
+#pragma warning disable IDE0025 // Use expression body for property
+#pragma warning disable IDE0027 // Use expression body for accessor
+
 namespace Ipfs.Cryptography
 {
     internal abstract class Keccak : System.Security.Cryptography.HashAlgorithm
@@ -65,7 +69,10 @@ namespace Ipfs.Cryptography
         protected Keccak(int hashBitLength)
         {
             if (hashBitLength != 224 && hashBitLength != 256 && hashBitLength != 384 && hashBitLength != 512)
+            {
                 throw new ArgumentException("hashBitLength must be 224, 256, 384, or 512", "hashBitLength");
+            }
+
             Initialize();
             HashSizeValue = hashBitLength;
             switch (hashBitLength)
@@ -153,11 +160,19 @@ namespace Ipfs.Cryptography
         protected override void HashCore(byte[] array, int ibStart, int cbSize)
         {
             if (ibStart < 0)
+            {
                 throw new ArgumentOutOfRangeException("ibStart");
+            }
+
             if (cbSize > array.Length)
+            {
                 throw new ArgumentOutOfRangeException("cbSize");
+            }
+
             if (ibStart + cbSize > array.Length)
+            {
                 throw new ArgumentOutOfRangeException("ibStart or cbSize");
+            }
         }
     }
 }

--- a/src/Cryptography/KeccakManaged.cs
+++ b/src/Cryptography/KeccakManaged.cs
@@ -3,6 +3,10 @@
 
 using System;
 
+#pragma warning disable IDE0011 // Add braces
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
+#pragma warning disable IDE1006 // Naming Styles
+
 namespace Ipfs.Cryptography
 {
     internal partial class KeccakManaged : Keccak

--- a/src/DagLink.cs
+++ b/src/DagLink.cs
@@ -16,9 +16,9 @@ namespace Ipfs
         /// <param name="size">The serialised size (in bytes) of the linked node.</param>
         public DagLink(string? name, Cid id, long size)
         {
-            this.Name = name;
-            this.Id = id;
-            this.Size = size;
+            Name = name;
+            Id = id;
+            Size = size;
         }
 
         /// <summary>
@@ -30,9 +30,9 @@ namespace Ipfs
         /// </param>
         public DagLink(IMerkleLink link)
         {
-            this.Name = link.Name;
-            this.Id = link.Id;
-            this.Size = link.Size;
+            Name = link.Name;
+            Id = link.Id;
+            Size = link.Size;
         }
 
         /// <summary>
@@ -78,10 +78,8 @@ namespace Ipfs
         /// </param>
         public void Write(Stream stream)
         {
-            using (var cos = new CodedOutputStream(stream, true))
-            {
-                Write(cos);
-            }
+            using var cos = new CodedOutputStream(stream, true);
+            Write(cos);
         }
 
         /// <summary>
@@ -107,10 +105,8 @@ namespace Ipfs
 
         private (string?, Cid, long) Read(Stream stream)
         {
-            using (var cis = new CodedInputStream(stream, true))
-            {
-                return Read(cis);
-            }
+            using var cis = new CodedInputStream(stream, true);
+            return Read(cis);
         }
 
         private (string?, Cid, long) Read(CodedInputStream stream)
@@ -153,11 +149,9 @@ namespace Ipfs
         /// </returns>
         public byte[] ToArray()
         {
-            using (var ms = new MemoryStream())
-            {
-                Write(ms);
-                return ms.ToArray();
-            }
+            using var ms = new MemoryStream();
+            Write(ms);
+            return ms.ToArray();
         }
 
     }

--- a/src/IKey.cs
+++ b/src/IKey.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Ipfs
+﻿namespace Ipfs
 {
     /// <summary>
     ///   Information about a cryptographic key.

--- a/src/ILinkedNode.cs
+++ b/src/ILinkedNode.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Ipfs
+﻿namespace Ipfs
 {
     /// <summary>
     ///   InterPlanetary Linked Data.

--- a/src/IPublishedMessage.cs
+++ b/src/IPublishedMessage.cs
@@ -1,7 +1,5 @@
-﻿using Ipfs.CoreApi;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
+using Ipfs.CoreApi;
 
 namespace Ipfs
 {
@@ -36,6 +34,5 @@ namespace Ipfs
         ///   A sender unique id for the message.
         /// </value>
         byte[] SequenceNumber { get; }
-
     }
 }

--- a/src/MultiBase.cs
+++ b/src/MultiBase.cs
@@ -31,16 +31,14 @@ namespace Ipfs
         /// <exception cref="KeyNotFoundException">
         ///   When <paramref name="name"/> is not registered.
         /// </exception>
-        static MultiBaseAlgorithm GetAlgorithm(string name)
+        private static MultiBaseAlgorithm GetAlgorithm(string name)
         {
-            try
+            if (MultiBaseAlgorithm.Names.TryGetValue(name, out MultiBaseAlgorithm? algorithm))
             {
-                return MultiBaseAlgorithm.Names[name];
+                return algorithm;
             }
-            catch (KeyNotFoundException)
-            {
-                throw new KeyNotFoundException($"MutiBase algorithm '{name}' is not registered.");
-            }
+
+            throw new KeyNotFoundException($"MultiBase algorithm '{name}' is not registered.");
         }
 
         /// <summary>
@@ -100,6 +98,5 @@ namespace Ipfs
                 throw new FormatException($"MultiBase '{s}' is invalid; decode failed.", e);
             }
         }
-
     }
 }

--- a/src/MultiCodec.cs
+++ b/src/MultiCodec.cs
@@ -24,7 +24,6 @@ namespace Ipfs
     /// <seealso cref="Registry.Codec"/>
     public static class MultiCodec
     {
-
         /// <summary>
         ///   Reads a <see cref="Codec"/> from the <see cref="Stream"/>. 
         /// </summary>

--- a/src/Peer.cs
+++ b/src/Peer.cs
@@ -11,8 +11,8 @@ namespace Ipfs
     /// </remarks>
     public class Peer : IEquatable<Peer>
     {
-        private static readonly MultiAddress[] noAddress = Array.Empty<MultiAddress>();
-        private const string unknown = "unknown/0.0";
+        private static readonly MultiAddress[] NoAddress = Array.Empty<MultiAddress>();
+        private const string Unknown = "unknown/0.0";
 
         /// <summary>
         ///   Universally unique identifier.
@@ -43,7 +43,7 @@ namespace Ipfs
         /// <value>
         ///   Where the peer can be found.  The default is an empty sequence.
         /// </value>
-        public IEnumerable<MultiAddress> Addresses { get; set; } = noAddress;
+        public IEnumerable<MultiAddress> Addresses { get; set; } = NoAddress;
 
         /// <summary>
         ///   The name and version of the IPFS software.
@@ -55,7 +55,7 @@ namespace Ipfs
         ///   There is no specification that describes the agent version string.  The default
         ///   is "unknown/0.0".
         /// </remarks>
-        public string AgentVersion { get; set; } = unknown;
+        public string AgentVersion { get; set; } = Unknown;
 
         /// <summary>
         ///  The name and version of the supported IPFS protocol.
@@ -67,7 +67,7 @@ namespace Ipfs
         ///   There is no specification that describes the protocol version string. The default
         ///   is "unknown/0.0".
         /// </remarks>
-        public string ProtocolVersion { get; set; } = unknown;
+        public string ProtocolVersion { get; set; } = Unknown;
 
         /// <summary>
         ///   The <see cref="MultiAddress"/> that the peer is connected on.
@@ -98,11 +98,11 @@ namespace Ipfs
         public bool IsValid()
         {
             if (Id is null)
+            {
                 return false;
-            if (PublicKey is not null && !Id.Matches(Convert.FromBase64String(PublicKey)))
-                return false;
+            }
 
-            return true;
+            return PublicKey is null || Id.Matches(Convert.FromBase64String(PublicKey));
         }
 
         /// <inheritdoc />
@@ -114,26 +114,26 @@ namespace Ipfs
         /// <inheritdoc />
         public override bool Equals(object? obj)
         {
-            var that = obj as Peer;
-            return (that is null)
-                ? false
-                : this.Equals(that);
+            return (obj is Peer that) && Equals(that);
         }
 
         /// <inheritdoc />
-        public bool Equals(Peer that)
-        {
-            return this.Id == that.Id;
-        }
+        public bool Equals(Peer that) => Id == that.Id;
 
         /// <summary>
         ///   Value equality.
         /// </summary>
         public static bool operator ==(Peer? a, Peer? b)
         {
-            if (object.ReferenceEquals(a, b)) return true;
-            if (a is null) return false;
-            if (b is null) return false;
+            if (object.ReferenceEquals(a, b))
+            {
+                return true;
+            }
+
+            if (a is null || b is null)
+            {
+                return false;
+            }
 
             return a.Equals(b);
         }
@@ -141,10 +141,7 @@ namespace Ipfs
         /// <summary>
         ///   Value inequality.
         /// </summary>
-        public static bool operator !=(Peer? a, Peer? b)
-        {
-            return !(a == b);
-        }
+        public static bool operator !=(Peer? a, Peer? b) => !(a == b);
 
         /// <summary>
         ///   Returns the <see cref="Base58"/> encoding of the <see cref="Id"/>.
@@ -169,9 +166,6 @@ namespace Ipfs
         /// <remarks>
         ///    Equivalent to <code>new Peer { Id = s }</code>
         /// </remarks>
-        static public implicit operator Peer(string s)
-        {
-            return new Peer { Id = s };
-        }
+        public static implicit operator Peer(string s) => new() { Id = s };
     }
 }

--- a/src/ProtobufHelper.cs
+++ b/src/ProtobufHelper.cs
@@ -4,14 +4,14 @@ using Google.Protobuf;
 
 namespace Ipfs
 {
-    static class ProtobufHelper
+    internal static class ProtobufHelper
     {
-        private static readonly MethodInfo writeRawBytes = typeof(CodedOutputStream)
+        private static readonly MethodInfo WriteRawBytes = typeof(CodedOutputStream)
             .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
             .Single(m =>
                 m.Name == "WriteRawBytes" && m.GetParameters().Count() == 1
             );
-        private static readonly MethodInfo readRawBytes = typeof(CodedInputStream)
+        private static readonly MethodInfo ReadRawBytes = typeof(CodedInputStream)
             .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
             .Single(m =>
                 m.Name == "ReadRawBytes"
@@ -19,12 +19,12 @@ namespace Ipfs
 
         public static void WriteSomeBytes(this CodedOutputStream stream, byte[] bytes)
         {
-            writeRawBytes.Invoke(stream, new object[] { bytes });
+            WriteRawBytes.Invoke(stream, new object[] { bytes });
         }
 
         public static byte[] ReadSomeBytes(this CodedInputStream stream, int length)
         {
-            return (byte[])readRawBytes.Invoke(stream, new object[] { length });
+            return (byte[])ReadRawBytes.Invoke(stream, new object[] { length });
         }
     }
 }

--- a/src/Registry/Codec.cs
+++ b/src/Registry/Codec.cs
@@ -14,8 +14,8 @@ namespace Ipfs.Registry
     /// <seealso href="https://github.com/multiformats/multicodec"/>
     public class Codec
     {
-        internal static Dictionary<string, Codec> Names = new Dictionary<string, Codec>();
-        internal static Dictionary<int, Codec> Codes = new Dictionary<int, Codec>();
+        internal static Dictionary<string, Codec> Names = new(StringComparer.Ordinal);
+        internal static Dictionary<int, Codec> Codes = new();
 
         /// <summary>
         ///   Register the standard multi-codecs for IPFS.
@@ -75,7 +75,7 @@ namespace Ipfs.Registry
         /// <summary>
         ///   Use <see cref="Register"/> to create a new instance of a <see cref="Codec"/>.
         /// </summary>
-        Codec()
+        private Codec()
         {
         }
 
@@ -111,11 +111,19 @@ namespace Ipfs.Registry
         public static Codec Register(string name, int code)
         {
             if (string.IsNullOrWhiteSpace(name))
+            {
                 throw new ArgumentNullException(nameof(name));
+            }
+
             if (Names.ContainsKey(name))
+            {
                 throw new ArgumentException(string.Format("The IPFS codec name '{0}' is already defined.", name));
+            }
+
             if (Codes.ContainsKey(code))
+            {
                 throw new ArgumentException(string.Format("The IPFS codec code '{0}' is already defined.", code));
+            }
 
             var a = new Codec
             {
@@ -145,10 +153,6 @@ namespace Ipfs.Registry
         /// <value>
         ///   All the registered codecs.
         /// </value>
-        public static IEnumerable<Codec> All
-        {
-            get { return Names.Values; }
-        }
-
+        public static IEnumerable<Codec> All => Names.Values;
     }
 }

--- a/src/Registry/HashingAlgorithm.cs
+++ b/src/Registry/HashingAlgorithm.cs
@@ -37,8 +37,8 @@ namespace Ipfs.Registry
     /// </remarks>
     public class HashingAlgorithm
     {
-        internal static Dictionary<string, HashingAlgorithm> Names = new Dictionary<string, HashingAlgorithm>();
-        internal static Dictionary<int, HashingAlgorithm> Codes = new Dictionary<int, HashingAlgorithm>();
+        internal static Dictionary<string, HashingAlgorithm> Names = new(StringComparer.Ordinal);
+        internal static Dictionary<int, HashingAlgorithm> Codes = new();
 
         /// <summary>
         ///   Register the standard hash algorithms for IPFS.
@@ -108,7 +108,7 @@ namespace Ipfs.Registry
         /// <summary>
         ///   Use <see cref="Register"/> to create a new instance of a <see cref="HashingAlgorithm"/>.
         /// </summary>
-        HashingAlgorithm()
+        private HashingAlgorithm()
         {
         }
 
@@ -142,11 +142,20 @@ namespace Ipfs.Registry
         public static HashingAlgorithm Register(string name, int code, int digestSize, Func<HashAlgorithm>? hasher = null)
         {
             if (string.IsNullOrWhiteSpace(name))
+            {
                 throw new ArgumentNullException(nameof(name));
+            }
+
             if (Names.ContainsKey(name))
+            {
                 throw new ArgumentException($"The IPFS hashing algorithm '{name}' is already defined.");
+            }
+
             if (Codes.ContainsKey(code))
+            {
                 throw new ArgumentException($"The IPFS hashing algorithm code 0x{code:x2} is already defined.");
+            }
+
             hasher ??= () => throw new NotImplementedException($"The IPFS hashing algorithm '{name}' is not implemented.");
 
             var a = new HashingAlgorithm
@@ -177,13 +186,24 @@ namespace Ipfs.Registry
         public static HashingAlgorithm RegisterAlias(string alias, string name)
         {
             if (string.IsNullOrWhiteSpace(alias))
+            {
                 throw new ArgumentNullException(nameof(alias));
+            }
+
             if (Names.ContainsKey(alias))
+            {
                 throw new ArgumentException($"The IPFS hashing algorithm '{alias}' is already defined and cannot be used as an alias.");
+            }
+
             if (string.IsNullOrWhiteSpace(name))
+            {
                 throw new ArgumentNullException(nameof(name));
+            }
+
             if (!Names.TryGetValue(name, out HashingAlgorithm existing))
+            {
                 throw new ArgumentException($"The IPFS hashing algorithm '{name}' is not defined.");
+            }
 
             var a = new HashingAlgorithm
             {
@@ -215,10 +235,7 @@ namespace Ipfs.Registry
         /// <value>
         ///   The currently registered hashing algorithms.
         /// </value>
-        public static IEnumerable<HashingAlgorithm> All
-        {
-            get { return Names.Values; }
-        }
+        public static IEnumerable<HashingAlgorithm> All => Names.Values;
 
         /// <summary>
         ///   Gets the <see cref="HashAlgorithm"/> with the specified IPFS multi-hash name.
@@ -262,6 +279,5 @@ namespace Ipfs.Registry
                 throw new KeyNotFoundException($"Hash algorithm '{name}' is not registered.");
             }
         }
-
     }
 }

--- a/src/Registry/MultiBaseAlgorithm .cs
+++ b/src/Registry/MultiBaseAlgorithm .cs
@@ -18,8 +18,8 @@ namespace Ipfs.Registry
     /// </remarks>
     public class MultiBaseAlgorithm
     {
-        internal static Dictionary<string, MultiBaseAlgorithm> Names = new Dictionary<string, MultiBaseAlgorithm>();
-        internal static Dictionary<char, MultiBaseAlgorithm> Codes = new Dictionary<char, MultiBaseAlgorithm>();
+        internal static Dictionary<string, MultiBaseAlgorithm> Names = new(StringComparer.Ordinal);
+        internal static Dictionary<char, MultiBaseAlgorithm> Codes = new();
 
         /// <summary>
         ///   Register the standard multi-base algorithms for IPFS.
@@ -113,7 +113,7 @@ namespace Ipfs.Registry
         /// <summary>
         ///   Use <see cref="Register"/> to create a new instance of a <see cref="MultiBaseAlgorithm"/>.
         /// </summary>
-        MultiBaseAlgorithm()
+        private MultiBaseAlgorithm()
         {
         }
 
@@ -152,11 +152,20 @@ namespace Ipfs.Registry
             Func<string, byte[]>? decode = null)
         {
             if (string.IsNullOrWhiteSpace(name))
+            {
                 throw new ArgumentNullException(nameof(name));
+            }
+
             if (Names.ContainsKey(name))
+            {
                 throw new ArgumentException($"The IPFS multi-base algorithm name '{name}' is already defined.");
+            }
+
             if (Codes.ContainsKey(code))
+            {
                 throw new ArgumentException($"The IPFS multi-base algorithm code '{code}' is already defined.");
+            }
+
             encode ??= bytes => throw new NotImplementedException($"The IPFS encode multi-base algorithm '{name}' is not implemented.");
             decode ??= s => throw new NotImplementedException($"The IPFS decode multi-base algorithm '{name}' is not implemented.");
 
@@ -188,10 +197,6 @@ namespace Ipfs.Registry
         /// <summary>
         ///   A sequence consisting of all algorithms.
         /// </summary>
-        public static IEnumerable<MultiBaseAlgorithm> All
-        {
-            get { return Names.Values; }
-        }
-
+        public static IEnumerable<MultiBaseAlgorithm> All => Names.Values;
     }
 }

--- a/src/VarInt.cs
+++ b/src/VarInt.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -41,11 +38,9 @@ namespace Ipfs
         /// </returns>
         public static byte[] Encode(long value)
         {
-            using (var stream = new MemoryStream(64))
-            {
-                stream.WriteVarint(value);
-                return stream.ToArray();
-            }
+            using var stream = new MemoryStream(64);
+            stream.WriteVarint(value);
+            return stream.ToArray();
         }
 
         /// <summary>
@@ -72,11 +67,9 @@ namespace Ipfs
         /// <returns>The integer value.</returns>
         public static int DecodeInt32 (byte[] bytes, int offset = 0)
         {
-            using (var stream = new MemoryStream(bytes, false))
-            {
-                stream.Position = offset;
-                return stream.ReadVarint32();
-            }
+            using var stream = new MemoryStream(bytes, false);
+            stream.Position = offset;
+            return stream.ReadVarint32();
         }
 
         /// <summary>
@@ -91,11 +84,9 @@ namespace Ipfs
         /// <returns>The integer value.</returns>
         public static long DecodeInt64(byte[] bytes, int offset = 0)
         {
-            using (var stream = new MemoryStream(bytes, false))
-            {
-                stream.Position = offset;
-                return stream.ReadVarint64();
-            }
+            using var stream = new MemoryStream(bytes, false);
+            stream.Position = offset;
+            return stream.ReadVarint64();
         }
 
         /// <summary>
@@ -126,7 +117,7 @@ namespace Ipfs
         ///   When the no bytes exist in the <paramref name="stream"/>.
         /// </exception>
         /// <exception cref="InvalidDataException">
-        ///   When the varint value is greater than <see cref="Int32.MaxValue"/>.
+        ///   When the varint value is greater than <see cref="int.MaxValue"/>.
         /// </exception>
         /// <returns>The integer value.</returns>
         public static int ReadVarint32(this Stream stream)
@@ -144,7 +135,7 @@ namespace Ipfs
         ///   When the no bytes exist in the <paramref name="stream"/>.
         /// </exception>
         /// <exception cref="InvalidDataException">
-        ///   When the varint value is greater than <see cref="Int64.MaxValue"/>.
+        ///   When the varint value is greater than <see cref="long.MaxValue"/>.
         /// </exception>
         /// <returns>The integer value.</returns>
         public static long ReadVarint64(this Stream stream)
@@ -171,10 +162,12 @@ namespace Ipfs
         /// <exception cref="NotSupportedException">
         ///   When <paramref name="value"/> is negative.
         /// </exception>
-        public static async Task WriteVarintAsync(this Stream stream, long value, CancellationToken cancel = default(CancellationToken))
+        public static async Task WriteVarintAsync(this Stream stream, long value, CancellationToken cancel = default)
         {
             if (value < 0)
+            {
                 throw new NotSupportedException("Negative values are not allowed for a Varint");
+            }
 
             var bytes = new byte[10];
             int i = 0;
@@ -182,7 +175,10 @@ namespace Ipfs
             {
                 byte v = (byte)(value & 0x7F);
                 if (value > 0x7F)
+                {
                     v |= 0x80;
+                }
+
                 bytes[i++] = v;
                 value >>= 7;
             } while (value != 0);
@@ -206,14 +202,12 @@ namespace Ipfs
         ///   When the no bytes exist in the <paramref name="stream"/>.
         /// </exception>
         /// <exception cref="InvalidDataException">
-        ///   When the varint value is greater than <see cref="Int32.MaxValue"/>.
+        ///   When the varint value is greater than <see cref="int.MaxValue"/>.
         /// </exception>
-        public static async Task<int> ReadVarint32Async(this Stream stream, CancellationToken cancel = default(CancellationToken))
+        public static async Task<int> ReadVarint32Async(this Stream stream, CancellationToken cancel = default)
         {
             var value = await stream.ReadVarint64Async(cancel).ConfigureAwait(false);
-            if (value > int.MaxValue)
-                throw new InvalidDataException("Varint value is bigger than an Int32.MaxValue");
-            return (int)value;
+            return value > int.MaxValue ? throw new InvalidDataException("Varint value is bigger than an Int32.MaxValue") : (int)value;
         }
 
         /// <summary>
@@ -226,7 +220,7 @@ namespace Ipfs
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
         /// <exception cref="InvalidDataException">
-        ///   When the varint value is greater than <see cref="Int64.MaxValue"/>.
+        ///   When the varint value is greater than <see cref="long.MaxValue"/>.
         /// </exception>
         /// <exception cref="EndOfStreamException">
         ///   When the no bytes exist in the <paramref name="stream"/>.
@@ -235,7 +229,7 @@ namespace Ipfs
         ///   A task that represents the asynchronous operation. The task's result
         ///   is the integer value in the <paramref name="stream"/>.
         /// </returns>
-        public static async Task<long> ReadVarint64Async(this Stream stream, CancellationToken cancel = default(CancellationToken))
+        public static async Task<long> ReadVarint64Async(this Stream stream, CancellationToken cancel = default)
         {
             long value = 0;
             int shift = 0;
@@ -246,19 +240,26 @@ namespace Ipfs
                 if (1 != await stream.ReadAsync(buffer, 0, 1, cancel).ConfigureAwait(false))
                 {
                     if (bytesRead == 0)
+                    {
                         throw new EndOfStreamException();
+                    }
 
                     throw new InvalidDataException("Varint is not terminated");
                 }
                 if (++bytesRead > 9)
+                {
                     throw new InvalidDataException("Varint value is bigger than an Int64.MaxValue");
+                }
+
                 var b = buffer[0];
                 value |= (long)(b & 0x7F) << shift;
                 if (b < 0x80)
+                {
                     return value;
+                }
+
                 shift += 7;
             }
         }
-
     }
 }

--- a/test/Base32Test.cs
+++ b/test/Base32Test.cs
@@ -7,7 +7,7 @@ namespace Ipfs
     [TestClass]
     public class Base32EncodeTests
     {
-        byte[] GetStringBytes(string x)
+        private static byte[] GetStringBytes(string x)
         {
             return Encoding.ASCII.GetBytes(x);
         }
@@ -58,7 +58,7 @@ namespace Ipfs
     [TestClass]
     public class Base32DecodeTests
     {
-        byte[] GetStringBytes(string x)
+        private static byte[] GetStringBytes(string x)
         {
             return Encoding.ASCII.GetBytes(x);
         }

--- a/test/Base58Test.cs
+++ b/test/Base58Test.cs
@@ -28,9 +28,9 @@ namespace Ipfs
         [TestMethod]
         public void Java()
         {
-            String input = "QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB";
+            string input = "QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB";
             byte[] output = Base58.Decode(input);
-            String encoded = Base58.Encode(output);
+            string encoded = Base58.Encode(output);
             Assert.AreEqual(input, encoded);
         }
 

--- a/test/CidTest.cs
+++ b/test/CidTest.cs
@@ -391,7 +391,7 @@ namespace Ipfs
             ExceptionAssert.Throws<NotSupportedException>(() => cid.Version = 0);
         }
 
-        class CidAndX
+        private class CidAndX
         {
             public Cid? Cid;
             public int X;

--- a/test/CoreApi/AddFileOptionsTest.cs
+++ b/test/CoreApi/AddFileOptionsTest.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Linq;
-using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ipfs.CoreApi

--- a/test/CoreApi/BitswapLedgerTest.cs
+++ b/test/CoreApi/BitswapLedgerTest.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ipfs.CoreApi
 {

--- a/test/CoreApi/ObjectStatTest.cs
+++ b/test/CoreApi/ObjectStatTest.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ipfs.CoreApi
 {
@@ -25,6 +22,5 @@ namespace Ipfs.CoreApi
             Assert.AreEqual(4, stat.LinkCount);
             Assert.AreEqual(5, stat.LinkSize);
         }
-
     }
 }

--- a/test/CoreApi/PingResultTest.cs
+++ b/test/CoreApi/PingResultTest.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Linq;
-using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ipfs.CoreApi
@@ -22,6 +20,5 @@ namespace Ipfs.CoreApi
             Assert.AreEqual("ping", r.Text);
             Assert.AreEqual(time, r.Time);
         }
-
     }
 }

--- a/test/Cryptography/HashingTest.cs
+++ b/test/Cryptography/HashingTest.cs
@@ -6,16 +6,16 @@ namespace Ipfs.Cryptography
     [TestClass]
     public class HashingTest
     {
-        static readonly string Merkle = Encoding.UTF8.GetBytes("Merkle–Damgård").ToHexString();
+        private static readonly string Merkle = Encoding.UTF8.GetBytes("Merkle–Damgård").ToHexString();
 
-        class TestVector
+        private class TestVector
         {
             public string? Algorithm { get; set; }
             public string? Input { get; set; }
             public string? Digest { get; set; }
         }
 
-        readonly TestVector[] TestVectors = new TestVector[]
+        private static readonly TestVector[] TestVectors =
         {
             new TestVector
             {

--- a/test/DagNodeTest.cs
+++ b/test/DagNodeTest.cs
@@ -218,7 +218,7 @@ namespace Ipfs
             RoundtripTest(b);
         }
 
-        void RoundtripTest(DagNode a)
+        private static void RoundtripTest(DagNode a)
         {
             var ms = new MemoryStream();
             a.Write(ms);

--- a/test/DurationTest.cs
+++ b/test/DurationTest.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Text;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.IO;
 
 namespace Ipfs
 {
-
     [TestClass]
     public class DurationTest
     {
@@ -96,4 +91,3 @@ namespace Ipfs
         }
     }
 }
-

--- a/test/ExceptionAssert.cs
+++ b/test/ExceptionAssert.cs
@@ -9,7 +9,6 @@ namespace Ipfs
     /// </summary>
     public static class ExceptionAssert
     {
-
         public static T Throws<T>(Action action, string? expectedMessage = null) where T : Exception
         {
             try
@@ -22,7 +21,10 @@ namespace Ipfs
                 if (match is not null)
                 {
                     if (expectedMessage is not null)
+                    {
                         Assert.AreEqual(expectedMessage, match.Message, "Wrong exception message.");
+                    }
+
                     return match;
                 }
 
@@ -31,7 +33,10 @@ namespace Ipfs
             catch (T e)
             {
                 if (expectedMessage is not null)
+                {
                     Assert.AreEqual(expectedMessage, e.Message);
+                }
+
                 return e;
             }
             Assert.Fail("Exception of type {0} should be thrown.", typeof(T));
@@ -40,9 +45,16 @@ namespace Ipfs
             throw new Exception();
         }
 
-        public static Exception Throws(Action action, string? expectedMessage = null)
+        // Avoids analyzer recommendations related to unused values.
+        public static T Throws<T, TTest>(Func<TTest> func) where T : Exception
         {
-            return Throws<Exception>(action, expectedMessage);
+            return Throws<T>(() => { var t = func(); });
+        }
+
+        // Avoids analyzer recommendations related to unused values.
+        public static T Throws<T, TTest>(Func<TTest> func, string? expectedMessage = null) where T : Exception
+        {
+            return Throws<T>(() => { var t = func(); }, expectedMessage);
         }
     }
 }

--- a/test/HexStringTest.cs
+++ b/test/HexStringTest.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Text;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
@@ -37,7 +35,7 @@ namespace Ipfs
         [TestMethod]
         public void InvalidFormatSpecifier()
         {
-            ExceptionAssert.Throws<FormatException>(() => HexString.Encode(new byte[0], "..."));
+            ExceptionAssert.Throws<FormatException>(() => HexString.Encode(Array.Empty<byte>(), "..."));
         }
 
         [TestMethod]

--- a/test/MultBaseTest.cs
+++ b/test/MultBaseTest.cs
@@ -39,14 +39,14 @@ namespace Ipfs
             ExceptionAssert.Throws<FormatException>(() => MultiBase.Decode("fXX"));
         }
 
-        class TestVector
+        private class TestVector
         {
             public string? Algorithm { get; set; }
             public string? Input { get; set; }
             public string? Output { get; set; }
         }
 
-        readonly TestVector[] TestVectors = new TestVector[]
+        private static readonly TestVector[] TestVectors = new TestVector[]
         {
             new TestVector {
                 Algorithm = "base16",

--- a/test/MultiAddressTest.cs
+++ b/test/MultiAddressTest.cs
@@ -6,17 +6,16 @@ using Newtonsoft.Json;
 
 namespace Ipfs
 {
-
     [TestClass]
     public class MultiAddressTest
     {
-        const string somewhere = "/ip4/10.1.10.10/tcp/29087/ipfs/QmVcSqVEsvm5RR9mBLjwpb2XjFVn5bPdPL69mL8PH45pPC";
-        const string nowhere = "/ip4/10.1.10.11/tcp/29087/ipfs/QmVcSqVEsvm5RR9mBLjwpb2XjFVn5bPdPL69mL8PH45pPC";
+        private const string Somewhere = "/ip4/10.1.10.10/tcp/29087/ipfs/QmVcSqVEsvm5RR9mBLjwpb2XjFVn5bPdPL69mL8PH45pPC";
+        private const string Nowhere = "/ip4/10.1.10.11/tcp/29087/ipfs/QmVcSqVEsvm5RR9mBLjwpb2XjFVn5bPdPL69mL8PH45pPC";
 
         [TestMethod]
         public void Parsing()
         {
-            var a = new MultiAddress(somewhere);
+            var a = new MultiAddress(Somewhere);
             Assert.AreEqual(3, a.Protocols.Count);
             Assert.AreEqual("ip4", a.Protocols[0].Name);
             Assert.AreEqual("10.1.10.10", a.Protocols[0].Value);
@@ -33,27 +32,27 @@ namespace Ipfs
         [TestMethod]
         public void Unknown_Protocol_Name()
         {
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("/foobar/123"));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("/foobar/123"));
         }
 
         [TestMethod]
         public void Missing_Protocol_Name()
         {
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("/"));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("/"));
         }
 
         [TestMethod]
         public new void ToString()
         {
-            Assert.AreEqual(somewhere, new MultiAddress(somewhere).ToString());
+            Assert.AreEqual(Somewhere, new MultiAddress(Somewhere).ToString());
         }
 
         [TestMethod]
         public void Value_Equality()
         {
-            var a0 = new MultiAddress(somewhere);
-            var a1 = new MultiAddress(somewhere);
-            var b = new MultiAddress(nowhere);
+            var a0 = new MultiAddress(Somewhere);
+            var a1 = new MultiAddress(Somewhere);
+            var b = new MultiAddress(Nowhere);
             MultiAddress? c = null;
             MultiAddress? d = null;
 
@@ -83,9 +82,9 @@ namespace Ipfs
             Assert.AreEqual(a0, a1);
             Assert.AreNotEqual(a0, b);
 
-            Assert.AreEqual<MultiAddress>(a0, a0);
-            Assert.AreEqual<MultiAddress>(a0, a1);
-            Assert.AreNotEqual<MultiAddress>(a0, b);
+            Assert.AreEqual(a0, a0);
+            Assert.AreEqual(a0, a1);
+            Assert.AreNotEqual(a0, b);
 
             Assert.AreEqual(a0.GetHashCode(), a0.GetHashCode());
             Assert.AreEqual(a0.GetHashCode(), a1.GetHashCode());
@@ -96,26 +95,26 @@ namespace Ipfs
         public void Bad_Port()
         {
             var tcp = new MultiAddress("/tcp/65535");
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("/tcp/x"));
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("/tcp/65536"));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("/tcp/x"));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("/tcp/65536"));
 
             var udp = new MultiAddress("/udp/65535");
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("/upd/x"));
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("/udp/65536"));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("/upd/x"));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("/udp/65536"));
         }
 
         [TestMethod]
         public void Bad_IPAddress()
         {
             var ipv4 = new MultiAddress("/ip4/127.0.0.1");
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("/ip4/x"));
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("/ip4/127."));
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("/ip4/::1"));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("/ip4/x"));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("/ip4/127."));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("/ip4/::1"));
 
             var ipv6 = new MultiAddress("/ip6/::1");
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("/ip6/x"));
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("/ip6/03:"));
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("/ip6/127.0.0.1"));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("/ip6/x"));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("/ip6/03:"));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("/ip6/127.0.0.1"));
         }
 
         [TestMethod]
@@ -132,7 +131,7 @@ namespace Ipfs
             };
             foreach (var badCase in badCases)
             {
-                ExceptionAssert.Throws<Exception>(() => new MultiAddress(badCase));
+                ExceptionAssert.Throws<Exception, MultiAddress>(() => new MultiAddress(badCase));
             }
          }
 
@@ -141,7 +140,7 @@ namespace Ipfs
         {
             var addresses = new[]
             {
-                somewhere,
+                Somewhere,
                 "/ip4/1.2.3.4/tcp/80/http",
                 "/ip6/3ffe:1900:4545:3:200:f8ff:fe21:67cf/tcp/443/https",
                 "/ip6/3ffe:1900:4545:3:200:f8ff:fe21:67cf/udp/8001",
@@ -171,33 +170,33 @@ namespace Ipfs
                 ma0.Write(ms);
                 ms.Position = 0;
                 var ma1 = new MultiAddress(ms);
-                Assert.AreEqual<MultiAddress>(ma0, ma1);
+                Assert.AreEqual(ma0, ma1);
 
                 var ma2 = new MultiAddress(ma0.ToString());
-                Assert.AreEqual<MultiAddress>(ma0, ma2);
+                Assert.AreEqual(ma0, ma2);
 
                 var ma3 = new MultiAddress(ma0.ToArray());
-                Assert.AreEqual<MultiAddress>(ma0, ma3);
+                Assert.AreEqual(ma0, ma3);
             }
         }
 
         [TestMethod]
         public void Reading_Invalid_Code()
         {
-            ExceptionAssert.Throws<InvalidDataException>(() => new MultiAddress(new byte[] { 0x7F }));
+            ExceptionAssert.Throws<InvalidDataException, MultiAddress>(() => new MultiAddress(new byte[] { 0x7F }));
         }
 
 
         [TestMethod]
         public void Reading_Invalid_Text()
         {
-            ExceptionAssert.Throws<FormatException>(() => new MultiAddress("tcp/80"));
+            ExceptionAssert.Throws<FormatException, MultiAddress>(() => new MultiAddress("tcp/80"));
         }
 
         [TestMethod]
         public void Implicit_Conversion_From_String()
         {
-            MultiAddress a = somewhere;
+            MultiAddress a = Somewhere;
             Assert.IsInstanceOfType(a, typeof(MultiAddress));
         }
 
@@ -322,7 +321,7 @@ namespace Ipfs
         {
             var a = new MultiAddress("/ip6/fe80::7573:b0a8:46b0:0bad/tcp/4009");
             string json = JsonConvert.SerializeObject(a);
-            Assert.AreEqual($"\"{a.ToString()}\"", json);
+            Assert.AreEqual($"\"{a}\"", json);
             var b = JsonConvert.DeserializeObject<MultiAddress>(json);
             Assert.IsNotNull(b);
             Assert.AreEqual(a.ToString(), b!.ToString());
@@ -409,4 +408,3 @@ namespace Ipfs
         }
     }
 }
-

--- a/test/NamedContentTest.cs
+++ b/test/NamedContentTest.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Text;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.IO;
-using Google.Protobuf;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ipfs
 {
@@ -22,6 +16,5 @@ namespace Ipfs
             Assert.AreEqual("/ipfs/...", nc.ContentPath);
             Assert.AreEqual("/ipns/...", nc.NamePath);
         }
-
     }
 }

--- a/test/NetworkProtocolTest.cs
+++ b/test/NetworkProtocolTest.cs
@@ -1,11 +1,7 @@
-using Ipfs;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.IO;
 using Google.Protobuf;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ipfs
 {
@@ -30,23 +26,22 @@ namespace Ipfs
             ExceptionAssert.Throws<ArgumentException>(() => NetworkProtocol.Register<CodeExists>());
         }
 
-        class NameExists : NetworkProtocol
+        private class NameExists : NetworkProtocol
         {
-            public override string Name { get { return "tcp"; } }
-            public override uint Code { get { return 0x7FFF; } }
+            public override string Name => "tcp";
+            public override uint Code => 0x7FFF;
             public override void ReadValue(CodedInputStream stream) { }
             public override void ReadValue(TextReader stream) { }
             public override void WriteValue(CodedOutputStream stream) { }
         }
 
-        class CodeExists : NetworkProtocol
+        private class CodeExists : NetworkProtocol
         {
-            public override string Name { get { return "x-tcp"; } }
-            public override uint Code { get { return 6; } }
+            public override string Name => "x-tcp";
+            public override uint Code => 6;
             public override void ReadValue(CodedInputStream stream) { }
             public override void ReadValue(TextReader stream) { }
             public override void WriteValue(CodedOutputStream stream) { }
         }
-
     }
 }

--- a/test/PeerTest.cs
+++ b/test/PeerTest.cs
@@ -7,29 +7,29 @@ namespace Ipfs
     [TestClass]
     public class PeerTest
     {
-        const string marsId = "QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3";
-        const string plutoId = "QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM";
-        const string marsPublicKey = "CAASogEwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKGUtbRQf+a9SBHFEruNAUatS/tsGUnHuCtifGrlbYPELD3UyyhWf/FYczBCavx3i8hIPEW2jQv4ehxQxi/cg9SHswZCQblSi0ucwTBFr8d40JEiyB9CcapiMdFQxdMgGvXEOQdLz1pz+UPUDojkdKZq8qkkeiBn7KlAoGEocnmpAgMBAAE=";
-        const string marsAddress = "/ip4/10.1.10.10/tcp/29087/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3";
+        private const string MarsId = "QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3";
+        private const string PlutoId = "QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM";
+        private const string MarsPublicKey = "CAASogEwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKGUtbRQf+a9SBHFEruNAUatS/tsGUnHuCtifGrlbYPELD3UyyhWf/FYczBCavx3i8hIPEW2jQv4ehxQxi/cg9SHswZCQblSi0ucwTBFr8d40JEiyB9CcapiMdFQxdMgGvXEOQdLz1pz+UPUDojkdKZq8qkkeiBn7KlAoGEocnmpAgMBAAE=";
+        private const string MarsAddress = "/ip4/10.1.10.10/tcp/29087/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3";
 
         [TestMethod]
         public new void ToString()
         {
-            Assert.AreEqual("", new Peer().ToString());
-            Assert.AreEqual(marsId, new Peer { Id = marsId }.ToString());
+            Assert.AreEqual(string.Empty, new Peer().ToString());
+            Assert.AreEqual(MarsId, new Peer { Id = MarsId }.ToString());
         }
 
         [TestMethod]
         public void DefaultValues()
         {
             var peer = new Peer();
-            Assert.AreEqual(null, peer.Id);
+            Assert.IsNull(peer.Id);
             Assert.AreEqual(0, peer.Addresses.Count());
             Assert.AreEqual("unknown/0.0", peer.ProtocolVersion);
             Assert.AreEqual("unknown/0.0", peer.AgentVersion);
-            Assert.AreEqual(null, peer.PublicKey);
+            Assert.IsNull(peer.PublicKey);
             Assert.AreEqual(false, peer.IsValid()); // missing peer ID
-            Assert.AreEqual(null, peer.ConnectedAddress);
+            Assert.IsNull(peer.ConnectedAddress);
             Assert.IsFalse(peer.Latency.HasValue);
         }
 
@@ -38,10 +38,10 @@ namespace Ipfs
         {
             var peer = new Peer
             {
-                ConnectedAddress = new MultiAddress(marsAddress),
+                ConnectedAddress = new MultiAddress(MarsAddress),
                 Latency = TimeSpan.FromHours(3.03 * 2)
             };
-            Assert.AreEqual(marsAddress, peer.ConnectedAddress.ToString());
+            Assert.AreEqual(MarsAddress, peer.ConnectedAddress.ToString());
             Assert.AreEqual(3.03 * 2, peer.Latency.Value.TotalHours);
         }
 
@@ -55,7 +55,7 @@ namespace Ipfs
         [TestMethod]
         public void Validation_With_Id()
         {
-            Peer peer = marsId;
+            Peer peer = MarsId;
             Assert.AreEqual(true, peer.IsValid());
         }
 
@@ -64,8 +64,8 @@ namespace Ipfs
         {
             var peer = new Peer
             {
-                Id = marsId,
-                PublicKey = marsPublicKey
+                Id = MarsId,
+                PublicKey = MarsPublicKey
             };
             Assert.AreEqual(true, peer.IsValid());
         }
@@ -75,8 +75,8 @@ namespace Ipfs
         {
             var peer = new Peer
             {
-                Id = plutoId,
-                PublicKey = marsPublicKey
+                Id = PlutoId,
+                PublicKey = MarsPublicKey
             };
             Assert.AreEqual(false, peer.IsValid());
         }
@@ -84,9 +84,9 @@ namespace Ipfs
         [TestMethod]
         public void Value_Equality()
         {
-            var a0 = new Peer { Id = marsId };
-            var a1 = new Peer { Id = marsId };
-            var b = new Peer { Id = plutoId };
+            var a0 = new Peer { Id = MarsId };
+            var a1 = new Peer { Id = MarsId };
+            var b = new Peer { Id = PlutoId };
             Peer? c = null;
             Peer? d = null;
 
@@ -129,10 +129,8 @@ namespace Ipfs
         [TestMethod]
         public void Implicit_Conversion_From_String()
         {
-            Peer a = marsId;
+            Peer a = MarsId;
             Assert.IsInstanceOfType(a, typeof(Peer));
         }
-
     }
 }
-

--- a/test/Registry/HashingAlgorithmTest.cs
+++ b/test/Registry/HashingAlgorithmTest.cs
@@ -11,15 +11,13 @@ namespace Ipfs.Registry
         [TestMethod]
         public void GetHasher()
         {
-            using (var hasher = HashingAlgorithm.GetAlgorithm("sha3-256"))
-            {
-                Assert.IsNotNull(hasher);
-                var input = new byte[] { 0xe9 };
-                var expected = "f0d04dd1e6cfc29a4460d521796852f25d9ef8d28b44ee91ff5b759d72c1e6d6".ToHexBuffer();
+            using var hasher = HashingAlgorithm.GetAlgorithm("sha3-256");
+            Assert.IsNotNull(hasher);
+            var input = new byte[] { 0xe9 };
+            var expected = "f0d04dd1e6cfc29a4460d521796852f25d9ef8d28b44ee91ff5b759d72c1e6d6".ToHexBuffer();
 
-                var actual = hasher.ComputeHash(input);
-                CollectionAssert.AreEqual(expected, actual);
-            }
+            var actual = hasher.ComputeHash(input);
+            CollectionAssert.AreEqual(expected, actual);
         }
 
         [TestMethod]

--- a/test/VarintTest.cs
+++ b/test/VarintTest.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Text;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ipfs
 {
@@ -55,7 +52,7 @@ namespace Ipfs
         [TestMethod]
         public void TooBig_Int32()
         {
-            var bytes = Varint.Encode((long)Int32.MaxValue + 1);
+            var bytes = Varint.Encode((long)int.MaxValue + 1);
             ExceptionAssert.Throws<InvalidDataException>(() => Varint.DecodeInt32(bytes));
         }
 
@@ -76,19 +73,17 @@ namespace Ipfs
         [TestMethod]
         public void Empty()
         {
-            var bytes = new byte[0];
+            var bytes = Array.Empty<byte>();
             ExceptionAssert.Throws<EndOfStreamException>(() => Varint.DecodeInt64(bytes));
         }
 
         [TestMethod]
         public async Task WriteAsync()
         {
-            using (var ms = new MemoryStream())
-            {
-                await ms.WriteVarintAsync(long.MaxValue);
-                ms.Position = 0;
-                Assert.AreEqual(long.MaxValue, ms.ReadVarint64());
-            }
+            using var ms = new MemoryStream();
+            await ms.WriteVarintAsync(long.MaxValue);
+            ms.Position = 0;
+            Assert.AreEqual(long.MaxValue, ms.ReadVarint64());
         }
 
         [TestMethod]
@@ -110,11 +105,9 @@ namespace Ipfs
         [TestMethod]
         public async Task ReadAsync()
         {
-            using (var ms = new MemoryStream("ffffffffffffffff7f".ToHexBuffer()))
-            {
-                var v = await ms.ReadVarint64Async();
-                Assert.AreEqual(long.MaxValue, v);
-            }
+            using var ms = new MemoryStream("ffffffffffffffff7f".ToHexBuffer());
+            var v = await ms.ReadVarint64Async();
+            Assert.AreEqual(long.MaxValue, v);
         }
 
         [TestMethod]
@@ -129,7 +122,7 @@ namespace Ipfs
         [TestMethod]
         public void Example()
         {
-            for (long v = 1; v <= 0xFFFFFFFL; v = v << 4)
+            for (long v = 1; v <= 0xFFFFFFFL; v <<= 4)
             {
                 Console.Write($"| {v} (0x{v.ToString("x")}) ");
                 Console.WriteLine($"| {Varint.Encode(v).ToHexString()} |");


### PR DESCRIPTION
For #9. The main style changes are to use a prefix '_' for private class fields and PascalCased for private static fields. The config also enforces use of private/internal scope specifiers, type aliases (e.g. 'int' over 'Int32'), consistent line endings for cacheability of source files in a canonical format, and braces around single-line statements. Other analyzer recommendations fixed in all files where possible.