### PR TITLE
Add base36 support, libp2p-key codec

### DIFF
--- a/src/Base32.cs
+++ b/src/Base32.cs
@@ -1,91 +1,85 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿namespace Ipfs;
 
-namespace Ipfs
+/// <summary>
+///   A codec for Base-32.
+/// </summary>
+/// <remarks>
+///   <para>
+///   A codec for Base-32, <see cref="Encode"/> and <see cref="Decode"/>.  Adds the extension method <see cref="ToBase32"/>
+///   to encode a byte array and <see cref="FromBase32"/> to decode a Base-32 string.
+///   </para>
+///   <para>
+///   <see cref="Encode"/> and <see cref="ToBase32"/> produce the lower case form of 
+///   <see href="https://tools.ietf.org/html/rfc4648"/> with no padding.
+///   <see cref="Decode"/> and <see cref="FromBase32"/> are case-insensitive and
+///   allow optional padding.
+///   </para>
+///   <para>
+///   A thin wrapper around <see href="https://github.com/ssg/SimpleBase"/>.
+///   </para>
+/// </remarks>
+public static class Base32
 {
     /// <summary>
-    ///   A codec for Base-32.
-    /// </summary>
-    /// <remarks>
-    ///   <para>
-    ///   A codec for Base-32, <see cref="Encode"/> and <see cref="Decode"/>.  Adds the extension method <see cref="ToBase32"/>
-    ///   to encode a byte array and <see cref="FromBase32"/> to decode a Base-32 string.
-    ///   </para>
-    ///   <para>
-    ///   <see cref="Encode"/> and <see cref="ToBase32"/> produce the lower case form of 
-    ///   <see href="https://tools.ietf.org/html/rfc4648"/> with no padding.
-    ///   <see cref="Decode"/> and <see cref="FromBase32"/> are case-insensitive and
-    ///   allow optional padding.
-    ///   </para>
-    ///   <para>
-    ///   A thin wrapper around <see href="https://github.com/ssg/SimpleBase"/>.
-    ///   </para>
-    /// </remarks>
-    public static class Base32
+    ///   Converts an array of 8-bit unsigned integers to its equivalent string representation that is 
+    ///   encoded with base-32 characters.
+    /// </summary>s
+    /// <param name="input">
+    ///   An array of 8-bit unsigned integers.
+    /// </param>
+    /// <returns>
+    ///   The string representation, in base 32, of the contents of <paramref name="input"/>.
+    /// </returns>
+    public static string Encode(byte[] input)
     {
-        /// <summary>
-        ///   Converts an array of 8-bit unsigned integers to its equivalent string representation that is 
-        ///   encoded with base-32 characters.
-        /// </summary>s
-        /// <param name="input">
-        ///   An array of 8-bit unsigned integers.
-        /// </param>
-        /// <returns>
-        ///   The string representation, in base 32, of the contents of <paramref name="input"/>.
-        /// </returns>
-        public static string Encode(byte[] input)
-        {
-            return SimpleBase.Base32.Rfc4648.Encode(input, false).ToLowerInvariant();
-        }
+        return SimpleBase.Base32.Rfc4648.Encode(input, false).ToLowerInvariant();
+    }
 
-        /// <summary>
-        ///   Converts an array of 8-bit unsigned integers to its equivalent string representation that is 
-        ///   encoded with base-32 digits.
-        /// </summary>
-        /// <param name="bytes">
-        ///   An array of 8-bit unsigned integers.
-        /// </param>
-        /// <returns>
-        ///   The string representation, in base 32, of the contents of <paramref name="bytes"/>.
-        /// </returns>
-        public static string ToBase32(this byte[] bytes)
-        {
-            return Encode(bytes);
-        }
+    /// <summary>
+    ///   Converts an array of 8-bit unsigned integers to its equivalent string representation that is 
+    ///   encoded with base-32 digits.
+    /// </summary>
+    /// <param name="bytes">
+    ///   An array of 8-bit unsigned integers.
+    /// </param>
+    /// <returns>
+    ///   The string representation, in base 32, of the contents of <paramref name="bytes"/>.
+    /// </returns>
+    public static string ToBase32(this byte[] bytes)
+    {
+        return Encode(bytes);
+    }
 
-        /// <summary>
-        ///   Converts the specified <see cref="string"/>, which encodes binary data as base 32 digits, 
-        ///   to an equivalent 8-bit unsigned integer array.
-        /// </summary>
-        /// <param name="input">
-        ///   The base 32 string to convert.
-        /// </param>
-        /// <returns>
-        ///   An array of 8-bit unsigned integers that is equivalent to <paramref name="input"/>.
-        /// </returns>
-        /// <remarks>
-        ///   <paramref name="input"/> is case-insensitive and allows padding.
-        /// </remarks>
-        public static byte[] Decode(string input)
-        {
-            return SimpleBase.Base32.Rfc4648.Decode(input);
-        }
+    /// <summary>
+    ///   Converts the specified <see cref="string"/>, which encodes binary data as base 32 digits, 
+    ///   to an equivalent 8-bit unsigned integer array.
+    /// </summary>
+    /// <param name="input">
+    ///   The base 32 string to convert.
+    /// </param>
+    /// <returns>
+    ///   An array of 8-bit unsigned integers that is equivalent to <paramref name="input"/>.
+    /// </returns>
+    /// <remarks>
+    ///   <paramref name="input"/> is case-insensitive and allows padding.
+    /// </remarks>
+    public static byte[] Decode(string input)
+    {
+        return SimpleBase.Base32.Rfc4648.Decode(input);
+    }
 
-        /// <summary>
-        ///   Converts the specified <see cref="string"/>, which encodes binary data as base 32 digits, 
-        ///   to an equivalent 8-bit unsigned integer array.
-        /// </summary>
-        /// <param name="s">
-        ///   The base 32 string to convert; case-insensitive and allows padding.
-        /// </param>
-        /// <returns>
-        ///   An array of 8-bit unsigned integers that is equivalent to <paramref name="s"/>.
-        /// </returns>
-        public static byte[] FromBase32(this string s)
-        {
-            return Decode(s);
-        }
+    /// <summary>
+    ///   Converts the specified <see cref="string"/>, which encodes binary data as base 32 digits, 
+    ///   to an equivalent 8-bit unsigned integer array.
+    /// </summary>
+    /// <param name="s">
+    ///   The base 32 string to convert; case-insensitive and allows padding.
+    /// </param>
+    /// <returns>
+    ///   An array of 8-bit unsigned integers that is equivalent to <paramref name="s"/>.
+    /// </returns>
+    public static byte[] FromBase32(this string s)
+    {
+        return Decode(s);
     }
 }

--- a/src/Base36.cs
+++ b/src/Base36.cs
@@ -138,7 +138,7 @@ namespace Ipfs
         {
             if (string.IsNullOrEmpty(s))
             {
-                throw new ArgumentException("Cannot decode a zero-length string.");
+                return Array.Empty<byte>();
             }
 
             int zeroCount = 0;

--- a/src/Base36.cs
+++ b/src/Base36.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+
+namespace Ipfs
+{
+    /// <summary>
+    ///   A codec for Base-36.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///   Provides encoding and decoding functionality for Base-36, with methods <see cref="EncodeToStringUc"/> and <see cref="EncodeToStringLc"/> for encoding, 
+    ///   and <see cref="DecodeString"/> for decoding. The encoding methods offer both uppercase and lowercase options.
+    ///   </para>
+    ///   <para>
+    ///   The implementation is case-insensitive for decoding and allows for efficient conversion between byte arrays and Base-36 strings.
+    ///   </para>
+    ///   <para>
+    ///   Ported from https://github.com/multiformats/go-base36/blob/v0.2.0/base36.go
+    ///   </para>
+    /// </remarks>
+    public static class Base36
+    {
+        // Constants for the encoding alphabets
+        private const string UcAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        private const string LcAlphabet = "0123456789abcdefghijklmnopqrstuvwxyz";
+        private const int MaxDigitOrdinal = 'z';
+        private const byte MaxDigitValueB36 = 35;
+
+        // Reverse lookup table for decoding
+        private static readonly byte[] RevAlphabet = new byte[MaxDigitOrdinal + 1];
+
+        // Static constructor to initialize the reverse lookup table
+        static Base36()
+        {
+            // Initialize the reverse alphabet array with default values
+            for (int i = 0; i < RevAlphabet.Length; i++)
+            {
+                RevAlphabet[i] = MaxDigitValueB36 + 1;
+            }
+
+            // Populate the reverse alphabet array for decoding
+            for (int i = 0; i < UcAlphabet.Length; i++)
+            {
+                char c = UcAlphabet[i];
+                RevAlphabet[c] = (byte)i;
+                if (c > '9')
+                {
+                    RevAlphabet[char.ToLower(c)] = (byte)i;
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Encodes a byte array to a Base-36 string using uppercase characters.
+        /// </summary>
+        /// <param name="bytes">
+        ///   The byte array to encode.
+        /// </param>
+        /// <returns>
+        ///   The encoded Base-36 string in uppercase.
+        /// </returns>
+        public static string EncodeToStringUc(byte[] bytes) => Encode(bytes, UcAlphabet);
+
+        /// <summary>
+        ///   Encodes a byte array to a Base-36 string using lowercase characters.
+        /// </summary>
+        /// <param name="bytes">
+        ///   The byte array to encode.
+        /// </param>
+        /// <returns>
+        ///   The encoded Base-36 string in lowercase.
+        /// </returns>
+        public static string EncodeToStringLc(byte[] bytes) => Encode(bytes, LcAlphabet);
+
+        // Core encoding logic for Base-36 conversion
+        private static string Encode(byte[] input, string alphabet)
+        {
+            int zeroCount = 0;
+            while (zeroCount < input.Length && input[zeroCount] == 0)
+            {
+                zeroCount++;
+            }
+
+            int size = zeroCount + (input.Length - zeroCount) * 277 / 179 + 1;
+            byte[] buffer = new byte[size];
+            int index, stopIndex;
+            uint carry;
+
+            stopIndex = size - 1;
+            for (int i = zeroCount; i < input.Length; i++)
+            {
+                index = size - 1;
+                carry = input[i];
+                while (index > stopIndex || carry != 0)
+                {
+                    carry += (uint)(buffer[index]) * 256;
+                    buffer[index] = (byte)(carry % 36);
+                    carry /= 36;
+                    index--;
+                }
+                stopIndex = index;
+            }
+
+            // The purpose of this loop is to skip over the portion of the buffer that contains only zeros (after accounting for any leading zeros in the original input).
+            // This is important for the encoding process, as these leading zeros are not represented in the base-36 encoded string.
+            for (stopIndex = zeroCount; stopIndex < size && buffer[stopIndex] == 0; stopIndex++)
+            {
+            }
+
+            // Once the first non-zero byte is found, the actual encoding of the non-zero part of the buffer can begin.
+            byte[] valueBuffer = new byte[buffer.Length - (stopIndex - zeroCount)];
+            for (int i = 0; i < valueBuffer.Length; i++)
+            {
+                valueBuffer[i] = (byte)alphabet[buffer[stopIndex - zeroCount + i]];
+            }
+
+            return Encoding.ASCII.GetString(valueBuffer);
+        }
+
+        /// <summary>
+        ///   Decodes a Base-36 encoded string to a byte array.
+        /// </summary>
+        /// <param name="s">
+        ///   The Base-36 encoded string to decode.
+        /// </param>
+        /// <returns>
+        ///   The decoded byte array.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   Thrown if the input string is null or empty.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   Thrown if the input string contains characters not valid in Base-36.
+        /// </exception>
+        public static byte[] DecodeString(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                throw new ArgumentException("Cannot decode a zero-length string.");
+            }
+
+            int zeroCount = 0;
+            while (zeroCount < s.Length && s[zeroCount] == '0')
+            {
+                zeroCount++;
+            }
+
+            byte[] binu = new byte[2 * ((s.Length) * 179 / 277 + 1)];
+            uint[] outi = new uint[(s.Length + 3) / 4];
+
+            foreach (char r in s)
+            {
+                if (r > MaxDigitOrdinal || RevAlphabet[r] > MaxDigitValueB36)
+                {
+                    throw new FormatException($"Invalid base36 character ({r}).");
+                }
+
+                ulong c = RevAlphabet[r];
+
+                for (int j = outi.Length - 1; j >= 0; j--)
+                {
+                    ulong t = (ulong)outi[j] * 36 + c;
+                    c = (t >> 32);
+                    outi[j] = (uint)(t & 0xFFFFFFFF);
+                }
+            }
+
+            uint mask = (uint)((s.Length % 4) * 8);
+            if (mask == 0)
+            {
+                mask = 32;
+            }
+            mask -= 8;
+
+            int outIndex = 0;
+            for (int j = 0; j < outi.Length; j++)
+            {
+                for (; mask < 32; mask -= 8)
+                {
+                    binu[outIndex] = (byte)(outi[j] >> (int)mask);
+                    outIndex++;
+                }
+                mask = 24;
+            }
+
+            for (int msb = zeroCount; msb < outIndex; msb++)
+            {
+                if (binu[msb] > 0)
+                {
+                    int lengthToCopy = outIndex - msb;
+                    byte[] result = new byte[lengthToCopy];
+                    Array.Copy(binu, msb, result, 0, lengthToCopy);
+                    return result;
+                }
+            }
+
+            return new byte[outIndex - zeroCount];
+        }
+    }
+}

--- a/src/IKey.cs
+++ b/src/IKey.cs
@@ -9,9 +9,12 @@
         ///   Unique identifier.
         /// </summary>
         /// <value>
-        ///   The <see cref="MultiHash"/> of the key's public key.
+        ///   A <see cref="Cid"/> containing the <see cref="MultiHash"/> of the public libp2p-key encoded in the requested Multibase.
         /// </value>
-        MultiHash Id { get; }
+        /// <remarks>
+        ///  The CID of the ipns libp2p-key encoded in the requested multibase.
+        /// </remarks>
+        Cid Id { get; }
 
         /// <summary>
         ///   The locally assigned name to the key.

--- a/src/IpfsCore.csproj
+++ b/src/IpfsCore.csproj
@@ -7,7 +7,7 @@
     <DebugType>portable</DebugType>
 
     <!-- https://semver.org/spec/v2.0.0.html -->
-    <Version>0.0.5</Version>
+    <Version>0.1.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
 
     <!-- Nuget specs -->

--- a/src/Registry/Codec.cs
+++ b/src/Registry/Codec.cs
@@ -35,6 +35,7 @@ namespace Ipfs.Registry
             Register("multibase", 0x33);
             Register("dag-pb", 0x70);
             Register("dag-cbor", 0x71);
+            Register("libp2p-key", 0x72);
             Register("git-raw", 0x78);
             Register("eth-block", 0x90);
             Register("eth-block-list", 0x91);

--- a/src/Registry/MultiBaseAlgorithm .cs
+++ b/src/Registry/MultiBaseAlgorithm .cs
@@ -57,6 +57,7 @@ namespace Ipfs.Registry
             Register("base32hexpad", 't',
                 bytes => SimpleBase.Base32.ExtendedHex.Encode(bytes, true).ToLowerInvariant(),
                 s => SimpleBase.Base32.ExtendedHex.Decode(s));
+            Register("base36", 'k', Base36.EncodeToStringLc, Base36.DecodeString);
             Register("BASE16", 'F',
                 bytes => SimpleBase.Base16.EncodeUpper(bytes),
                 s => SimpleBase.Base16.Decode(s));


### PR DESCRIPTION
## Background 

Since this code was written in 2019, the ipfs ecosystem has moved to using base36 Cidv1 as the default for the libp2p-key multihashes used for public peer ids and ipns public keys (see [RFC0001](https://github.com/libp2p/specs/pull/209)).

## Changes

This PR closes #26 and brings us up to speed with the latest defaults in Kubo's Key API.

- Support for Multicodec `libp2p-key` (0x72) was added
- Support for Base36 was added, as it's the default used in Kubo's Key API. This was ported from the [`go-base36`](https://github.com/multiformats/go-base36/blob/v0.2.0/base36.go) used by Boxo and Kubo.
- `IKey.Id` is now a Cid instead of a MultiHash, allowing support for both Cidv0 and Cidv1. Using MultiHash here would force dropping essential Cidv1 information, and only supports implicitly base58btc encoded Cidv0.  


