### PR TITLE
Release 0.2.0

### DIFF
--- a/src/CoreApi/IFileSystemApi.cs
+++ b/src/CoreApi/IFileSystemApi.cs
@@ -161,11 +161,9 @@ namespace Ipfs.CoreApi
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
         /// <returns>
-        ///   A task that represents the asynchronous operation. The task's value is
-        ///   an <see cref="IFileSystemNode"/>  The <see cref="IDataBlock.DataBytes"/>
-        ///   and <see cref="IDataBlock.DataStream"/> are set to <b>null</b>.
+        ///   A task that represents the asynchronous operation.
         /// </returns>
-        Task<IFileSystemNode> ListFileAsync(string path, CancellationToken cancel = default);
+        Task<IFileSystemNode> ListAsync(string path, CancellationToken cancel = default);
 
         /// <summary>
         ///   Download IPFS objects as a TAR archive.

--- a/src/IDataBlock.cs
+++ b/src/IDataBlock.cs
@@ -7,8 +7,7 @@ namespace Ipfs
     /// </summary>
     /// <remarks>
     ///   A <b>DataBlock</b> has an <see cref="Id">unique ID</see>
-    ///   and some data (<see cref="IDataBlock.DataBytes"/> 
-    ///   or <see cref="IDataBlock.DataStream"/>).
+    ///   and some data.
     ///   <para>
     ///   It is useful to talk about them as "blocks" in Bitswap 
     ///   and other things that do not care about what is being stored.
@@ -17,25 +16,6 @@ namespace Ipfs
     /// <seealso cref="IMerkleNode{Link}"/>
     public interface IDataBlock
     {
-        /// <summary>
-        ///   Contents as a byte array.
-        /// </summary>
-        /// <remarks>
-        ///   It is never <b>null</b>.
-        /// </remarks>
-        /// <value>
-        ///   The contents as a sequence of bytes.
-        /// </value>
-        byte[] DataBytes { get; }
-
-        /// <summary>
-        ///   Contents as a stream of bytes.
-        /// </summary>
-        /// <value>
-        ///   The contents as a stream of bytes.
-        /// </value>
-        Stream DataStream { get; }
-
         /// <summary>
         ///   The unique ID of the data.
         /// </summary>

--- a/src/IMerkleNode.cs
+++ b/src/IMerkleNode.cs
@@ -7,8 +7,7 @@ namespace Ipfs
     /// </summary>
     /// <remarks>
     ///   A <b>MerkleNode</b> has a sequence of navigable <see cref="Links"/>
-    ///   and some data (<see cref="IDataBlock.DataBytes"/> 
-    ///   or <see cref="IDataBlock.DataStream"/>).
+    ///   and some data.
     /// </remarks>
     /// <typeparam name="Link">
     ///   The type of <see cref="IMerkleLink"/> used by this node.

--- a/src/IPublishedMessage.cs
+++ b/src/IPublishedMessage.cs
@@ -12,6 +12,17 @@ namespace Ipfs
     public interface IPublishedMessage : IDataBlock
     {
         /// <summary>
+        ///   Contents as a byte array.
+        /// </summary>
+        /// <remarks>
+        ///   It is never <b>null</b>.
+        /// </remarks>
+        /// <value>
+        ///   The contents as a sequence of bytes.
+        /// </value>
+        byte[] DataBytes { get; }
+
+        /// <summary>
         ///   The sender of the message.
         /// </summary>
         /// <value>

--- a/src/IpfsCore.csproj
+++ b/src/IpfsCore.csproj
@@ -1,60 +1,74 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-    <AssemblyName>IpfsShipyard.Ipfs.Core</AssemblyName>
-    <RootNamespace>Ipfs</RootNamespace>
-    <DebugType>portable</DebugType>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+        <AssemblyName>IpfsShipyard.Ipfs.Core</AssemblyName>
+        <RootNamespace>Ipfs</RootNamespace>
+        <DebugType>portable</DebugType>
+        <LangVersion>12.0</LangVersion>
 
-    <!-- https://semver.org/spec/v2.0.0.html -->
-    <Version>0.1.0</Version>
-    <AssemblyVersion>$(Version)</AssemblyVersion>
+        <!-- https://semver.org/spec/v2.0.0.html -->
+        <Version>0.2.0</Version>
+        <AssemblyVersion>$(Version)</AssemblyVersion>
 
-    <!-- Nuget specs -->
-    <PackageId>IpfsShipyard.Ipfs.Core</PackageId>
-    <Authors>IPFS Shipyard, Arlo Godfrey, Richard Schneider</Authors>
-    <Title>IPFS Core Objects</Title>
-    <Description>
+        <!-- Nuget specs -->
+        <PackageId>IpfsShipyard.Ipfs.Core</PackageId>
+        <Authors>IPFS Shipyard, Arlo Godfrey, Richard Schneider</Authors>
+        <Title>IPFS Core Objects</Title>
+        <Description>
       Backed by the IPFS Shipyard and developer community. Picking up where Richard Schneider / makaretu left off.
       Core objects and interfaces for IPFS.
 
       The InterPlanetary File System is the permanent web. IPFS enables the creation of completely distributed applications. It is a new hypermedia distribution protocol, addressed by content and identities. It aims to make the web faster, safer, and more open.
     </Description>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageTags>ipfs peer-to-peer distributed file-system</PackageTags>
-    <IncludeSymbols>True</IncludeSymbols>
-    <PackageProjectUrl>https://github.com/ipfs-shipyard/net-ipfs-core</PackageProjectUrl>
-    <PackageIcon>icon.png</PackageIcon>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageTags>ipfs peer-to-peer distributed file-system</PackageTags>
+        <IncludeSymbols>True</IncludeSymbols>
+        <PackageProjectUrl>https://github.com/ipfs-shipyard/net-ipfs-core</PackageProjectUrl>
+        <PackageIcon>icon.png</PackageIcon>
 
-    <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+        <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageReleaseNotes>
+--- 0.2.0 ---
+[Breaking]
+IDataBlock.DataStream was removed. This pattern encouraged async calls behind synchronous property getters, which is a bad practice and can cause deadlocks. Call the async methods directly on the API instead.
+The obsolete IFileSystemApi.ListFileAsync was removed due to prior deprecation and removal in Kubo 0.26.0. Use IFileSystemApi.ListAsync and MfsApi.StatAsync instead. See https://github.com/ipfs/kubo/issues/7493#issuecomment-2016563729.
 
-  <PropertyGroup>
-    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
-    <EmbedUntrackedSources>false</EmbedUntrackedSources>
-    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb;$(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
+[New]
+Added missing IFileSystemApi.ListAsync. Doesn't fully replace the removed IFileSystemApi.ListFileAsync, but is a step in the right direction. See https://github.com/ipfs/kubo/issues/7493#issuecomment-2016563729.
+        </PackageReleaseNotes>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.21.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
-    <PackageReference Include="SimpleBase" Version="1.3.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.46.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
+    <PropertyGroup>
+        <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+        <EmbedUntrackedSources>false</EmbedUntrackedSources>
+        <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb;$(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <Protobuf Include="**/*.proto" />
-    <EmbeddedResource Include="**/*.proto" />
-    <None Include="icon.png" Pack="true" PackagePath="\" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Google.Protobuf" Version="3.21.1" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="PolySharp" Version="1.14.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
+        <PackageReference Include="SimpleBase" Version="1.3.1" />
+        <PackageReference Include="Grpc.Tools" Version="2.46.3" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Protobuf Include="**/*.proto" />
+        <EmbeddedResource Include="**/*.proto" />
+        <None Include="icon.png" Pack="true" PackagePath="\" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
[Breaking]
- IDataBlock.DataStream was removed. This pattern encouraged async calls behind synchronous property getters, which is a bad practice and can cause deadlocks. Call the async methods directly on the API instead.
- The obsolete `IFileSystemApi.ListFileAsync` was removed due to prior deprecation and removal in Kubo 0.26.0. Use `IFileSystemApi.ListAsync` and `MfsApi.StatAsync` instead. See https://github.com/ipfs/kubo/issues/7493#issuecomment-2016563729.

[New]
- Added missing `IFileSystemApi.ListAsync`. Doesn't fully replace the removed `IFileSystemApi.ListFileAsync`, but is a step in the right direction. See https://github.com/ipfs/kubo/issues/7493#issuecomment-2016563729.