### PR TITLE
Release 0.5.0. Added missing Name property to IFileSystemNode.

### DIFF
--- a/src/IFileSystemNode.cs
+++ b/src/IFileSystemNode.cs
@@ -13,5 +13,10 @@
         ///   it is some type of a file.
         /// </value>
         bool IsDirectory { get; }
+
+        /// <summary>
+        ///   The file name of the IPFS node.
+        /// </summary>
+        public string Name { get; }
     }
 }

--- a/src/IpfsCore.csproj
+++ b/src/IpfsCore.csproj
@@ -8,7 +8,7 @@
         <LangVersion>12.0</LangVersion>
 
         <!-- https://semver.org/spec/v2.0.0.html -->
-        <Version>0.4.0</Version>
+        <Version>0.5.0</Version>
         <AssemblyVersion>$(Version)</AssemblyVersion>
 
         <!-- Nuget specs -->
@@ -30,6 +30,10 @@
         <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
+--- 0.5.0 ---
+[Breaking]
+Added missing Name property to IFileSystemNode. This property was already present in the Ipfs.Http.FileSystemNode class, and is used in the MfsApi to get the name of the node. This is a breaking change, but it is unlikely that anyone has implemented this interface in their own code. If you have, you will need to add the Name property to your implementation. 
+
 --- 0.4.0 ---
 [Breaking]
 Added Mfs property to ICoreApi of type IMfsApi. The interface was added in a previous update, but it was not added to ICoreApi.


### PR DESCRIPTION
Property is present in primary core api implementation [here](https://github.com/ipfs-shipyard/net-ipfs-http-client/blob/01be61bcdbcb1b1ff32ac458eec9c289ba18b46f/src/FileSystemNode.cs). This PR adds the property to the interface so it  can be retrieved when using the core interfaces instead of the implementation types.