### PR TITLE
Add a bool Flush property to MfsWriteOptions

### DIFF
--- a/src/CoreApi/MfsWriteOptions.cs
+++ b/src/CoreApi/MfsWriteOptions.cs
@@ -77,5 +77,16 @@ namespace Ipfs.CoreApi
         /// </value>
         /// <seealso cref="MultiHash.DefaultAlgorithmName"/>
         public string? Hash { get; set; } = null;
+
+        /// <summary>
+        ///   Flush the data to disk after writing.
+        /// </summary>
+        /// <value>
+        ///   The default is <b>null</b> and the server will use its default of true.
+        /// </value>
+        /// <remarks>
+        ///   Use caution when setting this flag to false. It will improve performance for large numbers of file operations, but it does so at the cost of consistency guarantees. If the daemon is unexpectedly killed before running a proper flush, then data may be lost. This also applies to running the gc concurrently with flush false.
+        /// </remarks>
+        public bool? Flush { get; set; } = null;
     }
 }

--- a/src/IpfsCore.csproj
+++ b/src/IpfsCore.csproj
@@ -8,7 +8,7 @@
         <LangVersion>12.0</LangVersion>
 
         <!-- https://semver.org/spec/v2.0.0.html -->
-        <Version>0.6.0</Version>
+        <Version>0.6.1</Version>
         <AssemblyVersion>$(Version)</AssemblyVersion>
 
         <!-- Nuget specs -->
@@ -30,6 +30,10 @@
         <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
+--- 0.6.1 ---
+[New]
+Added missing MfsWriteOptions.Flush property. 
+
 --- 0.6.0 ---
 [Breaking]
 Added missing IMfsApi.ReadFileStreamAsync method.


### PR DESCRIPTION
Add a `Flush` property to `MfsWriteOptions` class.

* Add a new property `Flush` of type `bool?` with a default value of `null`.
* Document the `Flush` property in the class summary.
* Add remarks to the `Flush` property to caution about performance and consistency trade-offs. 

Note that this flag is mentioned in the [Kubo CLI docs](https://docs.ipfs.tech/reference/kubo/cli/#ipfs-files), but not the [Kubo RPC HTTP API docs](https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-files-flush).