### PR TITLE
Bugfix/network protocol missing tls

### DIFF
--- a/src/NetworkProtocol.cs
+++ b/src/NetworkProtocol.cs
@@ -38,6 +38,7 @@ namespace Ipfs
             NetworkProtocol.Register<CertHashNetworkProtocol>();
             NetworkProtocol.Register<HttpNetworkProtocol>();
             NetworkProtocol.Register<HttpsNetworkProtocol>();
+            NetworkProtocol.RegisterAlias<TlsNetworkProtocol>();
             NetworkProtocol.Register<DccpNetworkProtocol>();
             NetworkProtocol.Register<SctpNetworkProtocol>();
             NetworkProtocol.Register<WsNetworkProtocol>();
@@ -52,7 +53,6 @@ namespace Ipfs
             NetworkProtocol.Register<Dns6NetworkProtocol>();
             NetworkProtocol.Register<DnsAddrNetworkProtocol>();
             NetworkProtocol.Register<WssNetworkProtocol>();
-            NetworkProtocol.Register<TlsNetworkProtocol>();
             NetworkProtocol.Register<IpcidrNetworkProtocol>();
             NetworkProtocol.Register<WebRtcDirectNetworkProtocol>();
         }
@@ -479,7 +479,7 @@ namespace Ipfs
     internal class TlsNetworkProtocol : ValuelessNetworkProtocol
     {
         public override string Name => "tls";
-        public override uint Code => 448;
+        public override uint Code => 443;
     }
 
     internal class WsNetworkProtocol : ValuelessNetworkProtocol

--- a/src/NetworkProtocol.cs
+++ b/src/NetworkProtocol.cs
@@ -52,6 +52,7 @@ namespace Ipfs
             NetworkProtocol.Register<Dns6NetworkProtocol>();
             NetworkProtocol.Register<DnsAddrNetworkProtocol>();
             NetworkProtocol.Register<WssNetworkProtocol>();
+            NetworkProtocol.Register<TlsNetworkProtocol>();
             NetworkProtocol.Register<IpcidrNetworkProtocol>();
             NetworkProtocol.Register<WebRtcDirectNetworkProtocol>();
         }
@@ -473,6 +474,12 @@ namespace Ipfs
     {
         public override string Name => "https";
         public override uint Code => 443;
+    }
+
+    internal class TlsNetworkProtocol : ValuelessNetworkProtocol
+    {
+        public override string Name => "tls";
+        public override uint Code => 448;
     }
 
     internal class WsNetworkProtocol : ValuelessNetworkProtocol


### PR DESCRIPTION
There is a missing network protocol that causes at least the API Call /id, called IdAsync() in this API. Previously returned `Unknown protocol 'tls'` no matter what I tried. I tracked the problem to the missing NetworkProtocol.