### PR TITLE
Fix DagResolveOutput so that Dag.ResolveAsync works.

### DIFF
--- a/src/CoreApi/DagResolveOutput.cs
+++ b/src/CoreApi/DagResolveOutput.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// The result of a DAG resolve operation.
     /// </summary>
-    /// <param name="Id">The cid of the resolved dag path.</param>
+    /// <param name="Cid">The cid of the resolved dag path.</param>
     /// <param name="RemPath">Unknown usage. See <see href="https://github.com/ipfs/kubo/blob/f5b855550ca73acf5dd3a2001e2a7192cab7c249/core/commands/dag/dag.go#L54"/></param>
-    public record DagResolveOutput(DagCid Id, string RemPath);
+    public record DagResolveOutput(DagCid Cid, string RemPath);
 }


### PR DESCRIPTION
Self-descriptive title. The JSON return data structure had its first field wrong. The API returns "Cid", not "Id".