### PR TITLE
ci(build): use .NET 9 SDK; tests to net9.0 to avoid PolySharp error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Install .NET 6 SDK
+      - name: Setup .NET 9 SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.201'
+          dotnet-version: '9.0.x'
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,17 +11,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 6.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore -p:Configuration=Release
-    - name: Test
-      run: dotnet test --no-build --verbosity normal -p:Configuration=Release
-    - name: Publish to NuGet
-      run: dotnet nuget push "/home/runner/work/net-ipfs-core/net-ipfs-core/src/bin/Release/IpfsShipyard.Ipfs.Core.*.*.*.nupkg" --skip-duplicate --api-key ${{secrets.NUGET_KEY}} --source https://api.nuget.org/v3/index.json
+      - uses: actions/checkout@v4
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore -p:Configuration=Release
+      - name: Test
+        run: dotnet test --no-build --verbosity normal -p:Configuration=Release
+      - name: Publish to NuGet
+        run: dotnet nuget push "/home/runner/work/net-ipfs-core/net-ipfs-core/src/bin/Release/IpfsShipyard.Ipfs.Core.*.*.*.nupkg" --skip-duplicate --api-key ${{secrets.NUGET_KEY}} --source https://api.nuget.org/v3/index.json
       

--- a/test/IpfsCoreTests.csproj
+++ b/test/IpfsCoreTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
-    <langversion>10.0</langversion>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+    <langversion>13.0</langversion>
 
     <IsPackable>false</IsPackable>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
Update GitHub Actions runners to use .NET 9 SDK and retarget tests to net9.0.

This resolves CI failures from PolySharp (POLYSPCFG0001) requiring Roslyn 4.3+ on older SDKs.

- build.yml: setup-dotnet 9.0.x
- publish.yml: setup-dotnet 9.0.x
- test/IpfsCoreTests.csproj: TargetFrameworks=net9.0

No product code changes.