### PR TITLE
Pin API alignment: option and response records, streaming/progress options

### DIFF
--- a/src/CoreApi/AddFileOptions.cs
+++ b/src/CoreApi/AddFileOptions.cs
@@ -18,6 +18,14 @@ namespace Ipfs.CoreApi
         public bool? Pin { get; set; }
 
         /// <summary>
+        ///   Optional name to assign to the pin when pinning during add (Kubo v0.37.0+).
+        /// </summary>
+        /// <remarks>
+        ///   Forwarded as the 'pin-name' parameter to the add RPC. Effective when pinning is enabled.
+        /// </remarks>
+        public string? PinName { get; set; }
+
+        /// <summary>
         ///   Chunking algorithm, size-[bytes], rabin-[min]-[avg]-[max] or buzhash. Required: no.
         /// </summary>
         /// <value>

--- a/src/CoreApi/BlocksPinnedProgress.cs
+++ b/src/CoreApi/BlocksPinnedProgress.cs
@@ -1,0 +1,12 @@
+namespace Ipfs.CoreApi;
+
+/// <summary>
+///   Progress notification for pin/add reporting cumulative blocks pinned.
+/// </summary>
+public record BlocksPinnedProgress
+{
+    /// <summary>
+    ///   The cumulative number of blocks pinned so far.
+    /// </summary>
+    public int BlocksPinned { get; init; }
+}

--- a/src/CoreApi/IPinApi.cs
+++ b/src/CoreApi/IPinApi.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.Collections;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System;
 
 namespace Ipfs.CoreApi
 {
@@ -10,28 +13,34 @@ namespace Ipfs.CoreApi
     /// <seealso href="https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/PIN.md">Pin API spec</seealso>
     public interface IPinApi
     {
-        
+        /// <summary>
+        ///   Adds an IPFS object to the pinset and also stores it to the IPFS repo. pinset is the set of hashes currently pinned (not gc'able).
+        /// </summary>
+        /// <param name="path">
+        ///   A CID or path to an existing object, such as "QmXarR6rgkQ2fDSHjSY5nM2kuCXKYGViky5nohtwgF65Ec/about"
+        ///   or "QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V"
+        /// </param>
+        /// <param name="options">
+        ///   Options for pinning (name and recursion). If null, defaults are used.
+        /// </param>
+        /// <param name="cancel">
+        ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
+        /// </param>
+        /// <returns>
+        ///   A task that represents the asynchronous operation. The task's value
+        ///   is a sequence of <see cref="Cid"/> that were pinned.
+        /// </returns>
+        Task<IEnumerable<Cid>> AddAsync(string path, PinAddOptions options, CancellationToken cancel = default);
 
-    /// <summary>
-    ///   Adds an IPFS object to the pinset and also stores it to the IPFS repo. pinset is the set of hashes currently pinned (not gc'able).
-    /// </summary>
-    /// <param name="path">
-    ///   A CID or path to an existing object, such as "QmXarR6rgkQ2fDSHjSY5nM2kuCXKYGViky5nohtwgF65Ec/about"
-    ///   or "QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V"
-    /// </param>
-    /// <param name="options">
-    ///   Options for pinning (name and recursion). If null, defaults are used.
-    /// </param>
-    /// <param name="cancel">
-    ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
-    /// </param>
-    /// <returns>
-    ///   A task that represents the asynchronous operation. The task's value
-    ///   is a sequence of <see cref="Cid"/> that were pinned.
-    /// </returns>
-    Task<IEnumerable<Cid>> AddAsync(string path, PinAddOptions options, CancellationToken cancel = default);
-
-    // Removed multiple AddAsync overloads in favor of options-based overload above.
+        /// <summary>
+        ///   Adds an IPFS object to the pinset with progress reporting.
+        /// </summary>
+        /// <param name="path">The CID or path of the object to pin.</param>
+        /// <param name="options">Options for pinning (name and recursion).</param>
+        /// <param name="progress">Receives cumulative blocks-pinned updates.</param>
+        /// <param name="cancel">Cancellation token.</param>
+        /// <returns>Pinned CIDs on completion.</returns>
+        Task<IEnumerable<Cid>> AddAsync(string path, PinAddOptions options, IProgress<BlocksPinnedProgress> progress, CancellationToken cancel = default);
 
         /// <summary>
         ///   List all the objects pinned to local storage.
@@ -39,11 +48,8 @@ namespace Ipfs.CoreApi
         /// <param name="cancel">
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
-        /// <returns>
-        ///   A task that represents the asynchronous operation. The task's value
-        ///   is a sequence of <see cref="Cid"/>.
-        /// </returns>
-        Task<IEnumerable<Cid>> ListAsync(CancellationToken cancel = default);
+        /// <returns>An async sequence of <see cref="PinListItem"/>.</returns>
+        IAsyncEnumerable<PinListItem> ListAsync(CancellationToken cancel = default);
 
         /// <summary>
         ///   List all the objects pinned to local storage.
@@ -54,11 +60,16 @@ namespace Ipfs.CoreApi
         /// <param name="cancel">
         ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
         /// </param>
-        /// <returns>
-        ///   A task that represents the asynchronous operation. The task's value
-        ///   is a sequence of <see cref="Cid"/>.
-        /// </returns>
-        Task<IEnumerable<Cid>> ListAsync(PinType type, CancellationToken cancel = default);
+        /// <returns>An async sequence of <see cref="PinListItem"/>.</returns>
+        IAsyncEnumerable<PinListItem> ListAsync(PinType type, CancellationToken cancel = default);
+
+        /// <summary>
+        ///   List pinned objects with advanced options.
+        /// </summary>
+        /// <param name="options">List options (type filter, names, stream, etc.).</param>
+        /// <param name="cancel">Cancellation token.</param>
+        /// <returns>An async sequence of <see cref="PinListItem"/>.</returns>
+        IAsyncEnumerable<PinListItem> ListAsync(PinListOptions options, CancellationToken cancel = default);
 
         /// <summary>
         ///   Unpin an object.
@@ -78,5 +89,7 @@ namespace Ipfs.CoreApi
         ///   is a sequence of <see cref="Cid"/> that were unpinned.
         /// </returns>
         Task<IEnumerable<Cid>> RemoveAsync(Cid id, bool recursive = true, CancellationToken cancel = default);
+
+
     }
 }

--- a/src/CoreApi/IPinApi.cs
+++ b/src/CoreApi/IPinApi.cs
@@ -71,9 +71,13 @@ namespace Ipfs.CoreApi
         /// <returns>An async sequence of <see cref="PinListItem"/>.</returns>
         IAsyncEnumerable<PinListItem> ListAsync(PinListOptions options, CancellationToken cancel = default);
 
-        /// <summary>
-        ///   Unpin an object.
-        /// </summary>
+    /// <summary>
+    ///   Unpin an object.
+    /// </summary>
+    /// <remarks>
+    ///   Unpinning does not delete the object's blocks; they become eligible for garbage
+    ///   collection and are removed only when GC runs on the node.
+    /// </remarks>
         /// <param name="id">
         ///   The CID of the object.
         /// </param>

--- a/src/CoreApi/IPinApi.cs
+++ b/src/CoreApi/IPinApi.cs
@@ -10,25 +10,28 @@ namespace Ipfs.CoreApi
     /// <seealso href="https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/PIN.md">Pin API spec</seealso>
     public interface IPinApi
     {
-        /// <summary>
-        ///   Adds an IPFS object to the pinset and also stores it to the IPFS repo. pinset is the set of hashes currently pinned (not gc'able).
-        /// </summary>
-        /// <param name="path">
-        ///   A CID or path to an existing object, such as "QmXarR6rgkQ2fDSHjSY5nM2kuCXKYGViky5nohtwgF65Ec/about"
-        ///   or "QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V"
-        /// </param>
-        /// <param name="recursive">
-        ///   <b>true</b> to recursively pin links of the object; otherwise, <b>false</b> to only pin
-        ///   the specified object.  Default is <b>true</b>.
-        /// </param>
-        /// <param name="cancel">
-        ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
-        /// </param>
-        /// <returns>
-        ///   A task that represents the asynchronous operation. The task's value
-        ///   is a sequence of <see cref="Cid"/> that were pinned.
-        /// </returns>
-        Task<IEnumerable<Cid>> AddAsync(string path, bool recursive = true, CancellationToken cancel = default);
+        
+
+    /// <summary>
+    ///   Adds an IPFS object to the pinset and also stores it to the IPFS repo. pinset is the set of hashes currently pinned (not gc'able).
+    /// </summary>
+    /// <param name="path">
+    ///   A CID or path to an existing object, such as "QmXarR6rgkQ2fDSHjSY5nM2kuCXKYGViky5nohtwgF65Ec/about"
+    ///   or "QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V"
+    /// </param>
+    /// <param name="options">
+    ///   Options for pinning (name and recursion). If null, defaults are used.
+    /// </param>
+    /// <param name="cancel">
+    ///   Is used to stop the task.  When cancelled, the <see cref="TaskCanceledException"/> is raised.
+    /// </param>
+    /// <returns>
+    ///   A task that represents the asynchronous operation. The task's value
+    ///   is a sequence of <see cref="Cid"/> that were pinned.
+    /// </returns>
+    Task<IEnumerable<Cid>> AddAsync(string path, PinAddOptions options, CancellationToken cancel = default);
+
+    // Removed multiple AddAsync overloads in favor of options-based overload above.
 
         /// <summary>
         ///   List all the objects pinned to local storage.

--- a/src/CoreApi/IPinApi.cs
+++ b/src/CoreApi/IPinApi.cs
@@ -71,13 +71,13 @@ namespace Ipfs.CoreApi
         /// <returns>An async sequence of <see cref="PinListItem"/>.</returns>
         IAsyncEnumerable<PinListItem> ListAsync(PinListOptions options, CancellationToken cancel = default);
 
-    /// <summary>
-    ///   Unpin an object.
-    /// </summary>
-    /// <remarks>
-    ///   Unpinning does not delete the object's blocks; they become eligible for garbage
-    ///   collection and are removed only when GC runs on the node.
-    /// </remarks>
+        /// <summary>
+        ///   Unpin an object.
+        /// </summary>
+        /// <remarks>
+        ///   Unpinning does not delete the object's blocks; they become eligible for garbage
+        ///   collection and are removed only when GC runs on the node.
+        /// </remarks>
         /// <param name="id">
         ///   The CID of the object.
         /// </param>

--- a/src/CoreApi/PinAddOptions.cs
+++ b/src/CoreApi/PinAddOptions.cs
@@ -1,19 +1,55 @@
-namespace Ipfs.CoreApi
+using System.Collections.Generic;
+
+namespace Ipfs.CoreApi;
+
+
+/// <summary>
+///   A unified representation of a pin list entry that works for both
+///   streaming and non-streaming list responses.
+/// </summary>
+public record PinListItem
 {
     /// <summary>
-    ///   Options for pin add.
+    ///   The CID of the pinned object.
     /// </summary>
-    public class PinAddOptions
-    {
-        /// <summary>
-        ///   Optional name for created pin(s).
-        /// </summary>
-        public string? Name { get; set; }
+    public Ipfs.Cid Cid { get; init; } = null!;
 
-        /// <summary>
-        ///   True to recursively pin links of the object; otherwise, false to only pin the specified object.
-        ///   Default is true.
-        /// </summary>
-        public bool Recursive { get; set; } = true;
-    }
+    /// <summary>
+    ///   The pin type (direct, indirect, recursive).
+    /// </summary>
+    public PinType Type { get; init; }
+
+    /// <summary>
+    ///   Optional pin name (present when names are requested and set).
+    /// </summary>
+    public string? Name { get; init; }
+}
+
+
+/// <summary>
+///   Options for pin add.
+/// </summary>
+public record PinAddOptions
+{
+    /// <summary>
+    ///   Optional name for created pin(s).
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    ///   True to recursively pin links of the object; otherwise, false to only pin the specified object.
+    ///   Default is true.
+    /// </summary>
+    public bool Recursive { get; set; } = true;
+}
+
+/// <summary>
+///   Progress notification for pin/add reporting cumulative blocks pinned.
+/// </summary>
+public record BlocksPinnedProgress
+{
+    /// <summary>
+    ///   The cumulative number of blocks pinned so far.
+    /// </summary>
+    public int BlocksPinned { get; init; }
 }

--- a/src/CoreApi/PinAddOptions.cs
+++ b/src/CoreApi/PinAddOptions.cs
@@ -1,0 +1,19 @@
+namespace Ipfs.CoreApi
+{
+    /// <summary>
+    ///   Options for pin add.
+    /// </summary>
+    public class PinAddOptions
+    {
+        /// <summary>
+        ///   Optional name for created pin(s).
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        ///   True to recursively pin links of the object; otherwise, false to only pin the specified object.
+        ///   Default is true.
+        /// </summary>
+        public bool Recursive { get; set; } = true;
+    }
+}

--- a/src/CoreApi/PinAddOptions.cs
+++ b/src/CoreApi/PinAddOptions.cs
@@ -2,30 +2,6 @@ using System.Collections.Generic;
 
 namespace Ipfs.CoreApi;
 
-
-/// <summary>
-///   A unified representation of a pin list entry that works for both
-///   streaming and non-streaming list responses.
-/// </summary>
-public record PinListItem
-{
-    /// <summary>
-    ///   The CID of the pinned object.
-    /// </summary>
-    public Ipfs.Cid Cid { get; init; } = null!;
-
-    /// <summary>
-    ///   The pin type (direct, indirect, recursive).
-    /// </summary>
-    public PinType Type { get; init; }
-
-    /// <summary>
-    ///   Optional pin name (present when names are requested and set).
-    /// </summary>
-    public string? Name { get; init; }
-}
-
-
 /// <summary>
 ///   Options for pin add.
 /// </summary>
@@ -41,15 +17,4 @@ public record PinAddOptions
     ///   Default is true.
     /// </summary>
     public bool Recursive { get; set; } = true;
-}
-
-/// <summary>
-///   Progress notification for pin/add reporting cumulative blocks pinned.
-/// </summary>
-public record BlocksPinnedProgress
-{
-    /// <summary>
-    ///   The cumulative number of blocks pinned so far.
-    /// </summary>
-    public int BlocksPinned { get; init; }
 }

--- a/src/CoreApi/PinListItem.cs
+++ b/src/CoreApi/PinListItem.cs
@@ -1,0 +1,23 @@
+namespace Ipfs.CoreApi;
+
+/// <summary>
+///   A unified representation of a pin list entry that works for both
+///   streaming and non-streaming list responses.
+/// </summary>
+public record PinListItem
+{
+    /// <summary>
+    ///   The CID of the pinned object.
+    /// </summary>
+    public Ipfs.Cid Cid { get; init; } = null!;
+
+    /// <summary>
+    ///   The pin type (direct, indirect, recursive).
+    /// </summary>
+    public PinType Type { get; init; }
+
+    /// <summary>
+    ///   Optional pin name (present when names are requested and set).
+    /// </summary>
+    public string? Name { get; init; }
+}

--- a/src/CoreApi/PinListOptions.cs
+++ b/src/CoreApi/PinListOptions.cs
@@ -1,0 +1,34 @@
+namespace Ipfs.CoreApi;
+
+/// <summary>
+///   Options for pin list.
+/// </summary>
+public record PinListOptions
+{
+    /// <summary>
+    ///   The type of pinned keys to list. Can be "direct", "indirect", "recursive", or "all".
+    ///   Default is "all".
+    /// </summary>
+    public PinType Type { get; set; } = PinType.All;
+
+    /// <summary>
+    ///   Output only the CIDs of pins.
+    /// </summary>
+    public bool Quiet { get; set; }
+
+    /// <summary>
+    ///   Limit returned pins to ones with names that contain the value provided (case-sensitive, partial match).
+    ///   Implies Names = true.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    ///   Enable streaming of pins as they are discovered.
+    /// </summary>
+    public bool Stream { get; set; }
+
+    /// <summary>
+    ///   Include pin names in the output (slower, disabled by default).
+    /// </summary>
+    public bool Names { get; set; }
+}


### PR DESCRIPTION
## Summary

This PR was prepared by checking Kubo version changelogs 0.9.0 through 0.37.0 for any mentioned changes related to pinning, then these findings were cross-referenced with our existing codebase to identify the changes needed.

The IPinApi and a few other APIs that touch pinning (`add`, `dag import` etc.) have been brought fully in line with the (as yet unreleased) Kubo 0.37.0:
- Introduced an overload for IProgress/IAsyncEnumerable-based pin add progress reporting while preserving non-progress flow.
- [breaking] Refactored IPinApi.ListPinsAsync. Return type `Task<IEnumerable<Cid>>` is now `IAsyncEnumerable<PinListItem>`, and a `PinListOptions` param was added containing name filters, recurse and stream options.
- [breaking] Updated pin add to accept `PinAddOptions` (replaces the `recursive` boolean parameter).
    - Support named pins: added `Name` support (PinAddOptions/PinListItem) and optional name filter in `PinListOptions`.
- In the HTTP library, we've replaced JObject token handling with typed records/DTOs.
- We now respect Kubo defaults for DAG import (pin-roots default) and switch DAG export to POST.
- Add remarks that unpinning does not delete blocks; GC reclaims storage.

## Changes (core)
- Pin API
  - New `PinListOptions` and `PinListItem` domain model (list streaming and filtering preserved at the core surface).
  - `IPinApi.ListAsync(...)` unified as IAsyncEnumerable; added overload with `PinListOptions`.
  - `IPinApi.AddAsync(...)` updated to take `PinAddOptions` (replaces the `recursive` boolean); added overload with `IProgress<BlocksPinnedProgress>`.
  - Named pins: `PinAddOptions.Name`; `PinListItem.Name`; `PinListOptions.Name` filter and `Names` toggle.
  - Documentation: `RemoveAsync` remarks clarify that unpinning does not delete blocks; GC required to reclaim.
- DAG API
  - `DagApi.ImportAsync(...)`: omit `pin-roots` when null so Kubo default applies (roots pinned by default).
  - Model: `CarImportOutput` with `Root` and optional `Stats`.
 - File add options
   - `AddFileOptions`: added `PinName`; minor docs/option clarifications. In downstream HTTP client wiring, fixed `hash` parameter formatting and corrected `fscache` flag mapping.

## Tests
- Pin list: streaming and non-streaming coverage.
- Pin add: progress and non-progress coverage.
- Named pins (when supported by daemon): list names and name filtering covered at the HTTP client layer.
- DAG import/export (in http client):
  - Default pin roots respected, pin-roots=false does not pin; export/import roundtrip preserves root CID.

## Compatibility / Notes
- Kubo<=0.36.x lacks `--pin-name`; net-ipfs-core exposes property but behavior depends on daemon version.
- Some Kubo versions may not emit a dag import root line when `pin-roots=false`; the client tolerates this by returning an empty object.
- Breaking changes (core):
  - `IPinApi.ListAsync(...)` now returns `IAsyncEnumerable<PinListItem>` (previously returned a materialized collection of CIDs); also added `ListAsync(PinListOptions)`.
  - `IPinApi.AddAsync(...)` signature changed to use `PinAddOptions` (replaces the `recursive` bool parameter).
- Non-breaking additions:
  - New overload `IPinApi.AddAsync(..., IProgress<BlocksPinnedProgress> progress, ...)`.
  - `AddFileOptions.PinName` is additive and forward-compatible (effect depends on daemon version).
  - New types: `PinListOptions`, `PinListItem`.
  - Flag alias parity for `--name/-n` is provided at the HTTP client layer; core exposes the filter option.
