### PR TITLE
Release 0.8.0. Pin API alignment, dep updates, misc fixes.

### DIFF
--- a/src/IpfsCore.csproj
+++ b/src/IpfsCore.csproj
@@ -8,7 +8,7 @@
         <LangVersion>12.0</LangVersion>
 
         <!-- https://semver.org/spec/v2.0.0.html -->
-        <Version>0.7.0</Version>
+        <Version>0.8.0</Version>
         <AssemblyVersion>$(Version)</AssemblyVersion>
 
         <!-- Nuget specs -->
@@ -30,6 +30,36 @@
         <GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
+--- 0.8.0 ---
+[Breaking]
+Pin API alignment with Kubo 0.37.0:
+IPinApi.ListAsync now returns IAsyncEnumerable<PinListItem> and supports PinListOptions (filter by name, type direct/indirect/recursive/all, recurse, stream).
+IPinApi.AddAsync now accepts PinAddOptions (replaces the recursive bool parameter).
+Added overload AddAsync with IProgress<BlocksPinnedProgress> for streaming pin progress.
+
+[New]
+Named pins: PinAddOptions.Name and PinListItem.Name; PinListOptions.Name optionally filters. AddFileOptions.PinName to name pins created by file adds (behavior depends on daemon version).
+DAG import/export: respect Kubo defaults (pin-roots default), and switch DAG export to POST.
+
+[Fixed]
+Dag.ResolveAsync now works: DagResolveOutput uses Cid (not Id). (#46)
+MultiAddress: added tls protocol support (as alias of https) to prevent "Unknown protocol 'tls'". (#45)
+
+[Chore/CI]
+Use .NET 9 SDK in CI; test project targets net9.0 to satisfy PolySharp. (#51)
+Update actions/checkout to v5. (#48)
+Unified CI workflow templates. (#44)
+Internal refactors/cleanup.
+
+[Dependencies]
+Microsoft.Bcl.AsyncInterfaces 9.0.8.
+Portable.BouncyCastle 1.9.0.
+Test stack updates (MSTest.TestFramework/Adapter 3.10.2; Microsoft.NET.Test.Sdk 17.14.1). (#52)
+
+[Notes]
+Unpinning does not delete blocks; run GC to reclaim storage.
+Kubo versions less than 0.36.x do not support --pin-name; exposed properties are forward-compatible.
+
 --- 0.7.0 ---
 [Breaking]
 Fixed WebRTC-Direct support added in Kubo 0.30.0.


### PR DESCRIPTION
[Breaking]
Pin API alignment with Kubo 0.37.0:
IPinApi.ListAsync now returns IAsyncEnumerable<PinListItem> and supports PinListOptions (filter by name, type direct/indirect/recursive/all, recurse, stream).
IPinApi.AddAsync now accepts PinAddOptions (replaces the recursive bool parameter).
Added overload AddAsync with IProgress<BlocksPinnedProgress> for streaming pin progress.

[New]
Named pins: PinAddOptions.Name and PinListItem.Name; PinListOptions.Name optionally filters. AddFileOptions.PinName to name pins created by file adds (behavior depends on daemon version).
DAG import/export: respect Kubo defaults (pin-roots default), and switch DAG export to POST.

[Fixed]
Dag.ResolveAsync now works: DagResolveOutput uses Cid (not Id). (#46)
MultiAddress: added tls protocol support (as alias of https) to prevent "Unknown protocol 'tls'". (#45)

[Chore/CI]
Use .NET 9 SDK in CI; test project targets net9.0 to satisfy PolySharp. (#51)
Update actions/checkout to v5. (#48)
Unified CI workflow templates. (#44)
Internal refactors/cleanup.

[Dependencies]
Microsoft.Bcl.AsyncInterfaces 9.0.8.
Portable.BouncyCastle 1.9.0.
Test stack updates (MSTest.TestFramework/Adapter 3.10.2; Microsoft.NET.Test.Sdk 17.14.1). (#52)

[Notes]
Unpinning does not delete blocks; run GC to reclaim storage.
Kubo versions less than 0.36.x do not support --pin-name; exposed properties are forward-compatible.